### PR TITLE
filter out unconfigured studies; add RetryTest

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,37 @@
-Bridge-Exporter
-===============
-
+# Bridge Exporter (Bridge-EX)
 Worker app to aggregate Bridge uploads, survey answers, and health data daily, and export them to Synapse
+
+Set-up:
+In your home directory, add a file BridgeExporter.conf and add
+* Synapse username
+* Synapse API key
+* Synapse principal ID
+* local exporter DDB prefix
+* any other local overrides
+
+See main/resources/BridgeExporter.conf for an example. (Note that any attribute you don't add to your local conf file
+will fall back to the bundled conf file.)
+
+To run a full build (including compile, unit tests, findbugs, and jacoco test coverage), run:
+mvn verify
+
+(A full build takes about 1 min 15 seconds on my laptop, from a clean workspace.)
+
+To just run findbugs, run:
+mvn compile findbugs:check
+
+To run findbugs and get a friendly GUI to read about the bugs, run:
+mvn compile findbugs:findbugs findbugs:gui
+
+To run jacoco coverage reports and checks, run:
+mvn test jacoco:report jacoco:check
+
+Jacoco report will be in target/site/jacoco/index.html
+
+To run this locally, run
+mvn spring-boot:run
+
+
+Useful Spring Boot / Maven development resouces:
+http://stackoverflow.com/questions/27323104/spring-boot-and-maven-exec-plugin-issue
+http://techblog.molindo.at/2007/11/maven-unable-to-find-resources-in-test-cases.html

--- a/src/main/java/org/sagebionetworks/bridge/exporter/dynamo/StudyInfo.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/dynamo/StudyInfo.java
@@ -1,5 +1,7 @@
 package org.sagebionetworks.bridge.exporter.dynamo;
 
+import org.apache.commons.lang.StringUtils;
+
 /**
  * This class encapsulates study config for Bridge-EX. Note that once the Synapse tables are created and the project is
  * populated, THIS SHOULD NOT BE CHANGED. Otherwise, bad things happen.
@@ -42,11 +44,16 @@ public class StudyInfo {
         }
 
         /**
-         * Builds the study info object. Fields may be null (if Synapse config hasn't been created yet), so no
-         * validation needed.
+         * Builds the study info object. The study may not have been configured for Bridge-EX yet (that is, no
+         * dataAccessTeamId and no synapseProjectId). If that's the case, return null instead of returning an
+         * incomplete StudyInfo.
          */
         public StudyInfo build() {
-            return new StudyInfo(dataAccessTeamId, synapseProjectId);
+            if (dataAccessTeamId == null || StringUtils.isBlank(synapseProjectId)) {
+                return null;
+            } else {
+                return new StudyInfo(dataAccessTeamId, synapseProjectId);
+            }
         }
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/exporter/dynamo/StudyInfoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/dynamo/StudyInfoTest.java
@@ -7,10 +7,27 @@ import org.testng.annotations.Test;
 
 public class StudyInfoTest {
     @Test
-    public void nullFields() {
-        StudyInfo studyInfo = new StudyInfo.Builder().build();
-        assertNull(studyInfo.getDataAccessTeamId());
-        assertNull(studyInfo.getSynapseProjectId());
+    public void nullDataAccessTeam() {
+        StudyInfo studyInfo = new StudyInfo.Builder().withSynapseProjectId("test-synapse-project").build();
+        assertNull(studyInfo);
+    }
+
+    @Test
+    public void nullProject() {
+        StudyInfo studyInfo = new StudyInfo.Builder().withDataAccessTeamId(23L).build();
+        assertNull(studyInfo);
+    }
+
+    @Test
+    public void emptyProject() {
+        StudyInfo studyInfo = new StudyInfo.Builder().withDataAccessTeamId(23L).withSynapseProjectId("").build();
+        assertNull(studyInfo);
+    }
+
+    @Test
+    public void blankProject() {
+        StudyInfo studyInfo = new StudyInfo.Builder().withDataAccessTeamId(23L).withSynapseProjectId("   ").build();
+        assertNull(studyInfo);
     }
 
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/exporter/retry/RetryTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/retry/RetryTest.java
@@ -1,0 +1,29 @@
+package org.sagebionetworks.bridge.exporter.retry;
+
+import static org.testng.Assert.assertEquals;
+
+import java.util.concurrent.TimeUnit;
+
+import com.jcabi.aspects.RetryOnFailure;
+import org.testng.annotations.Test;
+
+// Basic test to test we properly integrated retry library.
+public class RetryTest {
+    private static class RetryTestHelper {
+        int timesCalled = 0;
+
+        @RetryOnFailure(attempts = 5, delay = 10, unit = TimeUnit.MILLISECONDS, randomize = false)
+        void call() {
+            if (++timesCalled < 5) {
+                throw new IllegalStateException();
+            }
+        }
+    }
+
+    @Test
+    public void testRetry() {
+        RetryTestHelper helper = new RetryTestHelper();
+        helper.call();
+        assertEquals(helper.timesCalled, 5);
+    }
+}


### PR DESCRIPTION
Changes:
- added filter to filter out unconfigured studies - This allows studies to "opt-in" to Bridge-EX 2.0
- added RetryTest to verify jcabi retry works
- updated ReadMe

Testing done:
- mvn verify (unit tests, code coverage, findbugs)
- manually tested that export still works
- didn't test unconfigured study
