### PR TITLE
Status Table; refactor table creation

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/exporter/handler/AppVersionExportHandler.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/handler/AppVersionExportHandler.java
@@ -10,6 +10,7 @@ import org.apache.commons.lang.StringUtils;
 import org.sagebionetworks.repo.model.table.ColumnModel;
 import org.sagebionetworks.repo.model.table.ColumnType;
 
+import org.sagebionetworks.bridge.exporter.synapse.SynapseHelper;
 import org.sagebionetworks.bridge.exporter.worker.ExportSubtask;
 import org.sagebionetworks.bridge.exporter.worker.ExportTask;
 import org.sagebionetworks.bridge.exporter.worker.TsvInfo;
@@ -34,12 +35,12 @@ public class AppVersionExportHandler extends SynapseExportHandler {
 
     @Override
     protected String getDdbTableName() {
-        return "SynapseMetaTables";
+        return SynapseHelper.DDB_TABLE_SYNAPSE_META_TABLES;
     }
 
     @Override
     protected String getDdbTableKeyName() {
-        return "tableName";
+        return SynapseHelper.DDB_KEY_TABLE_NAME;
     }
 
     @Override

--- a/src/main/java/org/sagebionetworks/bridge/exporter/synapse/SynapseStatusTableHelper.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/synapse/SynapseStatusTableHelper.java
@@ -1,0 +1,141 @@
+package org.sagebionetworks.bridge.exporter.synapse;
+
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.sagebionetworks.client.exceptions.SynapseException;
+import org.sagebionetworks.repo.model.table.ColumnModel;
+import org.sagebionetworks.repo.model.table.ColumnType;
+import org.sagebionetworks.repo.model.table.PartialRow;
+import org.sagebionetworks.repo.model.table.PartialRowSet;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import org.sagebionetworks.bridge.exporter.exceptions.BridgeExporterException;
+import org.sagebionetworks.bridge.exporter.worker.ExportTask;
+import org.sagebionetworks.bridge.exporter.worker.ExportWorkerManager;
+
+/**
+ * Highly specialized helper, which writes the status row to the Synapse status table, creating it if it doesn't
+ * already exist.
+ */
+@Component
+public class SynapseStatusTableHelper {
+    // Constants package-scoped to be available to unit tests.
+    static final String COLUMN_NAME_UPLOAD_DATE = "uploadDate";
+    static final List<ColumnModel> COLUMN_LIST;
+    static {
+        // Construct column definition list. This table is only used as a flag to signal that we're done uploading, so
+        // we only need one column with the date.
+        // NOTE: ColumnType.DATE is actually a timestamp. There is no calendar date type.
+        ColumnModel uploadDateColumn = new ColumnModel();
+        uploadDateColumn.setName(COLUMN_NAME_UPLOAD_DATE);
+        uploadDateColumn.setColumnType(ColumnType.STRING);
+        uploadDateColumn.setMaximumSize(10L);
+
+        COLUMN_LIST = ImmutableList.of(uploadDateColumn);
+    }
+
+    private ExportWorkerManager manager;
+    private SynapseHelper synapseHelper;
+
+    /**
+     * Export worker manager, used for its many utility methods, like get/setSynapseTableIdFromDdb, data access team,
+     * principal ID, parent project ID, etc.
+     */
+    @Autowired
+    final void setManager(ExportWorkerManager manager) {
+        this.manager = manager;
+    }
+
+    /** Synapse Helper, used to create the Synapse table. */
+    @Autowired
+    final void setSynapseHelper(SynapseHelper synapseHelper) {
+        this.synapseHelper = synapseHelper;
+    }
+
+    /**
+     * Writes the export task status to the status table for the given export task and study. If the status table
+     * doesn't exist, this will create it.
+     *
+     * @param task
+     *         export task to write status for
+     * @param studyId
+     *         study ID to write status for
+     * @throws BridgeExporterException
+     *         if there's an unusual condition, like mismatched table columns
+     * @throws InterruptedException
+     *         if a Synapse asynchronous request thread is interrupted
+     * @throws SynapseException
+     *         if the Synapse call fails
+     */
+    public void initTableAndWriteStatus(ExportTask task, String studyId) throws BridgeExporterException,
+            InterruptedException, SynapseException {
+        // Does the table already exist? If not, create it.
+        String synapseTableId = manager.getSynapseTableIdFromDdb(task, SynapseHelper.DDB_TABLE_SYNAPSE_META_TABLES,
+                SynapseHelper.DDB_KEY_TABLE_NAME, getStatusTableName(studyId));
+        if (synapseTableId == null) {
+            synapseTableId = createStatusTable(task, studyId);
+        }
+
+        // Table definitely exists now. Write status with this internal helper.
+        writeStatus(synapseTableId, task, studyId);
+    }
+
+    // Helper method that abstracts away the status table name, which is always "[studyId]-status".
+    private String getStatusTableName(String studyId) {
+        return studyId + "-status";
+    }
+
+    // Helper method to create the status table. It sets up the columns, then calls through Synapse Helper.
+    private String createStatusTable(ExportTask task, String studyId) throws BridgeExporterException,
+            SynapseException {
+        // Delegate table creation to SynapseHelper.
+        long dataAccessTeamId = manager.getDataAccessTeamIdForStudy(studyId);
+        long principalId = manager.getSynapsePrincipalId();
+        String projectId = manager.getSynapseProjectIdForStudyAndTask(studyId, task);
+        String tableName = getStatusTableName(studyId);
+        String synapseTableId = synapseHelper.createTableWithColumnsAndAcls(COLUMN_LIST, dataAccessTeamId, principalId,
+                projectId, tableName);
+
+        // write back to DDB table
+        manager.setSynapseTableIdToDdb(task, SynapseHelper.DDB_TABLE_SYNAPSE_META_TABLES,
+                SynapseHelper.DDB_KEY_TABLE_NAME, getStatusTableName(studyId), synapseTableId);
+
+        return synapseTableId;
+    }
+
+    // Helper method to write the actual status. It creates a partial row set, then calls through to the Synapse
+    // Helper to write the row set.
+    private void writeStatus(String synapseTableId, ExportTask task, String studyId) throws BridgeExporterException,
+            InterruptedException, SynapseException {
+        // The row set map is one column ID, so we need to get the column model from the table.
+        List<ColumnModel> columnList = synapseHelper.getColumnModelsForTableWithRetry(synapseTableId);
+        if (columnList.size() != 1) {
+            throw new BridgeExporterException("Wrong number of columns in status table for study " + studyId +
+                    ", expected 1 column, got " + columnList.size() + " columns");
+        }
+
+        // We know there is exactly one column in the status table.
+        ColumnModel column = columnList.get(0);
+        String colName = column.getName();
+        if (!COLUMN_NAME_UPLOAD_DATE.equals(colName)) {
+            throw new BridgeExporterException("Wrong column in status table for study " + studyId + ", expected " +
+                    COLUMN_NAME_UPLOAD_DATE + ", got " + colName);
+        }
+
+        String colId = column.getId();
+
+        // Make row set. We only need to write one row, and that row only has one column: the upload date.
+        PartialRow row = new PartialRow();
+        row.setValues(ImmutableMap.of(colId, task.getExporterDate().toString()));
+
+        PartialRowSet rowSet = new PartialRowSet();
+        rowSet.setRows(ImmutableList.of(row));
+        rowSet.setTableId(synapseTableId);
+
+        // write to Synapse
+        synapseHelper.appendRowsToTableWithRetry(rowSet, synapseTableId);
+    }
+}

--- a/src/main/java/org/sagebionetworks/bridge/exporter/worker/ExportTask.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/worker/ExportTask.java
@@ -2,9 +2,11 @@ package org.sagebionetworks.bridge.exporter.worker;
 
 import java.io.File;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.Queue;
+import java.util.Set;
 import java.util.concurrent.Future;
 
 import org.joda.time.LocalDate;
@@ -118,6 +120,7 @@ public class ExportTask {
     private final Map<String, TsvInfo> appVersionTsvInfoByStudy = new HashMap<>();
     private final Map<UploadSchemaKey, TsvInfo> healthDataTsvInfoBySchema = new HashMap<>();
     private final Queue<Future<?>> outstandingTaskQueue = new LinkedList<>();
+    private final Set<String> studyIdSet = new HashSet<>();
 
     /** Gets the appVersion table TSV info for the specified study. */
     public TsvInfo getAppVersionTsvInfoForStudy(String studyId) {
@@ -147,5 +150,15 @@ public class ExportTask {
     /** Adds a subtask to the queue for the task. */
     public void addOutstandingTask(Future<?> subtaskFuture) {
         outstandingTaskQueue.add(subtaskFuture);
+    }
+
+    /** Adds the study ID to the set of seen study IDs. */
+    public void addStudyId(String studyId) {
+        studyIdSet.add(studyId);
+    }
+
+    /** Gets the set of study IDs that were seen by this task. Used to do per-study post-processing. */
+    public Set<String> getStudyIdSet() {
+        return studyIdSet;
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/exporter/handler/SynapseExportHandlerNewTableTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/handler/SynapseExportHandlerNewTableTest.java
@@ -1,33 +1,23 @@
 package org.sagebionetworks.bridge.exporter.handler;
 
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.notNull;
 import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
-import com.amazonaws.services.dynamodbv2.document.DynamoDB;
-import com.amazonaws.services.dynamodbv2.document.Item;
-import com.amazonaws.services.dynamodbv2.document.Table;
-import org.mockito.ArgumentCaptor;
-import org.sagebionetworks.repo.model.AccessControlList;
-import org.sagebionetworks.repo.model.ResourceAccess;
 import org.sagebionetworks.repo.model.table.ColumnModel;
-import org.sagebionetworks.repo.model.table.TableEntity;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -41,20 +31,17 @@ import org.sagebionetworks.bridge.exporter.worker.ExportWorkerManager;
 import org.sagebionetworks.bridge.file.InMemoryFileHelper;
 import org.sagebionetworks.bridge.schema.UploadSchema;
 
-@SuppressWarnings({ "rawtypes", "unchecked" })
 public class SynapseExportHandlerNewTableTest {
-    private List<String> columnIdList;
-    private ArgumentCaptor<List> columnListCaptor;
+    private String ddbSynapseTableId;
+    private ExportWorkerManager manager;
     private SynapseHelper mockSynapseHelper;
-    private Table mockSynapseTableMap;
-    private List<ColumnModel> sourceColumnModelList;
-    private ArgumentCaptor<TableEntity> tableCaptor;
     private ExportTask task;
     private byte[] tsvBytes;
 
     @BeforeMethod
     public void before() {
-        // clear tsvBytes, because TestNG doesn't always do that
+        // clear test vars, because TestNG doesn't always do that
+        ddbSynapseTableId = null;
         tsvBytes = null;
     }
 
@@ -70,30 +57,6 @@ public class SynapseExportHandlerNewTableTest {
                 .thenReturn(SynapseExportHandlerTest.TEST_SYNAPSE_PRINCIPAL_ID);
         when(mockConfig.getInt(ExportWorkerManager.CONFIG_KEY_WORKER_MANAGER_PROGRESS_REPORT_PERIOD)).thenReturn(250);
 
-        // mock DDB table - no table registered in Synapse
-        Map<String, Item> mockSynapseTableMapInternalMap = new HashMap<>();
-        mockSynapseTableMap = mock(Table.class);
-
-        when(mockSynapseTableMap.getItem(eq(handler.getDdbTableKeyName()), any(String.class)))
-                .thenAnswer(invocation -> {
-                    String tableKeyValue = invocation.getArgumentAt(1, String.class);
-                    return mockSynapseTableMapInternalMap.get(tableKeyValue);
-                });
-
-        when(mockSynapseTableMap.putItem(any(Item.class))).thenAnswer(invocation -> {
-            Item newItem = invocation.getArgumentAt(0, Item.class);
-            String tableKeyValue = newItem.getString(handler.getDdbTableKeyName());
-            mockSynapseTableMapInternalMap.put(tableKeyValue, newItem);
-
-            // Mockito Answers assume a return value, so return null
-            return null;
-        });
-
-        // mock DDB client
-        DynamoDB mockDdbClient = mock(DynamoDB.class);
-        when(mockDdbClient.getTable(SynapseExportHandlerTest.DUMMY_DDB_PREFIX + handler.getDdbTableName())).thenReturn(
-                mockSynapseTableMap);
-
         // mock file helper
         InMemoryFileHelper mockFileHelper = new InMemoryFileHelper();
         File tmpDir = mockFileHelper.createTempDir();
@@ -102,33 +65,19 @@ public class SynapseExportHandlerNewTableTest {
         mockSynapseHelper = mock(SynapseHelper.class);
 
         // mock create columns - all we care about are column names and IDs
-        sourceColumnModelList = new ArrayList<>();
-        sourceColumnModelList.addAll(SynapseExportHandler.COMMON_COLUMN_LIST);
-        sourceColumnModelList.addAll(handler.getSynapseTableColumnList());
+        List<ColumnModel> columnModelList = new ArrayList<>();
+        columnModelList.addAll(SynapseExportHandler.COMMON_COLUMN_LIST);
+        columnModelList.addAll(handler.getSynapseTableColumnList());
 
-        List<ColumnModel> createdColumnModelList = new ArrayList<>();
-        columnIdList = new ArrayList<>();
-        for (ColumnModel oneColumn : sourceColumnModelList) {
-            String columnName = oneColumn.getName();
-            String columnId = columnName + "-ID";
-            ColumnModel createdColumn = new ColumnModel();
-            createdColumn.setName(columnName);
-            createdColumn.setId(columnId);
-            createdColumnModelList.add(createdColumn);
+        // mock create table with columns and ACLs
+        when(mockSynapseHelper.createTableWithColumnsAndAcls(columnModelList,
+                SynapseExportHandlerTest.TEST_SYNAPSE_DATA_ACCESS_TEAM_ID,
+                SynapseExportHandlerTest.TEST_SYNAPSE_PRINCIPAL_ID, SynapseExportHandlerTest.TEST_SYNAPSE_PROJECT_ID,
+                handler.getDdbTableKeyValue())).thenReturn(SynapseExportHandlerTest.TEST_SYNAPSE_TABLE_ID);
 
-            columnIdList.add(columnId);
-        }
-
-        columnListCaptor = ArgumentCaptor.forClass(List.class);
-        when(mockSynapseHelper.createColumnModelsWithRetry(columnListCaptor.capture())).thenReturn(
-                createdColumnModelList);
-
-        // mock create table - We only care about Table ID.
-        TableEntity createdTable = new TableEntity();
-        createdTable.setId(SynapseExportHandlerTest.TEST_SYNAPSE_TABLE_ID);
-
-        tableCaptor = ArgumentCaptor.forClass(TableEntity.class);
-        when(mockSynapseHelper.createTableWithRetry(tableCaptor.capture())).thenReturn(createdTable);
+        // mock get column model list
+        when(mockSynapseHelper.getColumnModelsForTableWithRetry(SynapseExportHandlerTest.TEST_SYNAPSE_TABLE_ID))
+                .thenReturn(columnModelList);
 
         // mock upload the TSV and capture the upload
         when(mockSynapseHelper.uploadTsvFileToTable(eq(SynapseExportHandlerTest.TEST_SYNAPSE_PROJECT_ID),
@@ -142,9 +91,8 @@ public class SynapseExportHandlerNewTableTest {
         });
 
         // setup manager - This is only used to get helper objects.
-        ExportWorkerManager manager = spy(new ExportWorkerManager());
+        manager = spy(new ExportWorkerManager());
         manager.setConfig(mockConfig);
-        manager.setDdbClient(mockDdbClient);
         manager.setFileHelper(mockFileHelper);
         manager.setSynapseHelper(mockSynapseHelper);
         handler.setManager(manager);
@@ -161,54 +109,22 @@ public class SynapseExportHandlerNewTableTest {
                 eq(SynapseExportHandlerTest.TEST_STUDY_ID), same(task));
         doReturn(SynapseExportHandlerTest.TEST_SYNAPSE_DATA_ACCESS_TEAM_ID).when(manager).getDataAccessTeamIdForStudy(
                 SynapseExportHandlerTest.TEST_STUDY_ID);
+
+        // Similarly, spy get/setSynapseTableIdFromDDB.
+        doAnswer(invocation -> ddbSynapseTableId).when(manager).getSynapseTableIdFromDdb(task,
+                handler.getDdbTableName(), handler.getDdbTableKeyName(), handler.getDdbTableKeyValue());
+        doAnswer(invocation -> ddbSynapseTableId = invocation.getArgumentAt(4, String.class)).when(manager)
+                .setSynapseTableIdToDdb(same(task), eq(handler.getDdbTableName()), eq(handler.getDdbTableKeyName()),
+                        eq(handler.getDdbTableKeyValue()), anyString());
     }
 
     private void validateTableCreation(SynapseExportHandler handler) throws Exception {
         // Don't bother validating metrics or line counts or even file cleanup. This is all tested in the normal case.
         // Just worry about Synapse table creation.
 
-        // validate Synapse create column args
-        assertEquals(columnListCaptor.getValue(), sourceColumnModelList);
-
-        // validate Synapse create table args
-        TableEntity table = tableCaptor.getValue();
-        assertEquals(table.getName(), handler.getDdbTableKeyValue());
-        assertEquals(table.getParentId(), SynapseExportHandlerTest.TEST_SYNAPSE_PROJECT_ID);
-        assertEquals(table.getColumnIds(), columnIdList);
-
-        // validate Synapse set ACLs args
-        ArgumentCaptor<AccessControlList> aclCaptor = ArgumentCaptor.forClass(AccessControlList.class);
-        verify(mockSynapseHelper).createAclWithRetry(aclCaptor.capture());
-
-        AccessControlList acl = aclCaptor.getValue();
-        assertEquals(acl.getId(), SynapseExportHandlerTest.TEST_SYNAPSE_TABLE_ID);
-
-        Set<ResourceAccess> resourceAccessSet = acl.getResourceAccess();
-        assertEquals(resourceAccessSet.size(), 2);
-
-        boolean hasExporterAccess = false;
-        boolean hasTeamAccess = false;
-        for (ResourceAccess oneAccess : resourceAccessSet) {
-            if (oneAccess.getPrincipalId() == SynapseExportHandlerTest.TEST_SYNAPSE_PRINCIPAL_ID) {
-                assertEquals(oneAccess.getAccessType(), SynapseExportHandler.ACCESS_TYPE_ALL);
-                hasExporterAccess = true;
-            } else if (oneAccess.getPrincipalId() == SynapseExportHandlerTest.TEST_SYNAPSE_DATA_ACCESS_TEAM_ID) {
-                assertEquals(oneAccess.getAccessType(), SynapseExportHandler.ACCESS_TYPE_READ);
-                hasTeamAccess = true;
-            } else {
-                fail("Unexpected resource access with principal ID " + oneAccess.getPrincipalId());
-            }
-        }
-        assertTrue(hasExporterAccess);
-        assertTrue(hasTeamAccess);
-
-        // validate DDB put args
-        ArgumentCaptor<Item> ddbPutItemArgCaptor = ArgumentCaptor.forClass(Item.class);
-        verify(mockSynapseTableMap).putItem(ddbPutItemArgCaptor.capture());
-
-        Item ddbPutItemArg = ddbPutItemArgCaptor.getValue();
-        assertEquals(ddbPutItemArg.getString(handler.getDdbTableKeyName()), handler.getDdbTableKeyValue());
-        assertEquals(ddbPutItemArg.getString(SynapseExportHandler.DDB_KEY_TABLE_ID), SynapseExportHandlerTest.TEST_SYNAPSE_TABLE_ID);
+        // validate setSynapseTableIdToDdb
+        verify(manager).setSynapseTableIdToDdb(task, handler.getDdbTableName(), handler.getDdbTableKeyName(),
+                handler.getDdbTableKeyValue(), SynapseExportHandlerTest.TEST_SYNAPSE_TABLE_ID);
     }
 
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/exporter/synapse/SynapseStatusTableHelperTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/synapse/SynapseStatusTableHelperTest.java
@@ -1,0 +1,138 @@
+package org.sagebionetworks.bridge.exporter.synapse;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyListOf;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.notNull;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+import java.util.List;
+import java.util.Map;
+
+import com.google.common.collect.ImmutableList;
+import org.joda.time.LocalDate;
+import org.mockito.ArgumentCaptor;
+import org.sagebionetworks.repo.model.table.ColumnModel;
+import org.sagebionetworks.repo.model.table.PartialRow;
+import org.sagebionetworks.repo.model.table.PartialRowSet;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import org.sagebionetworks.bridge.exporter.worker.ExportTask;
+import org.sagebionetworks.bridge.exporter.worker.ExportWorkerManager;
+
+@SuppressWarnings({ "rawtypes", "unchecked" })
+public class SynapseStatusTableHelperTest {
+    private static final String COLUMN_ID = "test-column-id";
+    private static final long DATA_ACCESS_TEAM_ID = 1234;
+    private static final long SYNAPSE_PRINCIPAL_ID = 5678;
+    private static final String SYNAPSE_PROJECT_ID = "test-synapse-project";
+    private static final String SYNAPSE_TABLE_ID = "test-synapse-table";
+
+    private static final String STUDY_ID = "test-study";
+    private static final String SYNAPSE_TABLE_NAME = "test-study-status";
+
+    private String synapseTableId;
+
+    @BeforeMethod
+    public void before() {
+        // clear helper vars, because TestNG doesn't always do that
+        synapseTableId = null;
+    }
+
+    @Test
+    public void test() throws Exception {
+        // mock manager
+        ExportWorkerManager mockManager = mock(ExportWorkerManager.class);
+        when(mockManager.getDataAccessTeamIdForStudy(STUDY_ID)).thenReturn(DATA_ACCESS_TEAM_ID);
+        when(mockManager.getSynapsePrincipalId()).thenReturn(SYNAPSE_PRINCIPAL_ID);
+        when(mockManager.getSynapseProjectIdForStudyAndTask(eq(STUDY_ID), notNull(ExportTask.class))).thenReturn(
+                SYNAPSE_PROJECT_ID);
+
+        // mock get/setSynapseTableIdFromDdb
+        when(mockManager.getSynapseTableIdFromDdb(notNull(ExportTask.class),
+                eq(SynapseHelper.DDB_TABLE_SYNAPSE_META_TABLES), eq(SynapseHelper.DDB_KEY_TABLE_NAME),
+                eq(SYNAPSE_TABLE_NAME))).thenAnswer(invocation -> synapseTableId);
+        doAnswer(invocation -> synapseTableId = invocation.getArgumentAt(4, String.class)).when(mockManager)
+                .setSynapseTableIdToDdb(notNull(ExportTask.class), eq(SynapseHelper.DDB_TABLE_SYNAPSE_META_TABLES),
+                        eq(SynapseHelper.DDB_KEY_TABLE_NAME), eq(SYNAPSE_TABLE_NAME), anyString());
+
+        // mock Synapse Helper
+        SynapseHelper mockSynapseHelper = mock(SynapseHelper.class);
+        when(mockSynapseHelper.createTableWithColumnsAndAcls(SynapseStatusTableHelper.COLUMN_LIST, DATA_ACCESS_TEAM_ID,
+                SYNAPSE_PRINCIPAL_ID, SYNAPSE_PROJECT_ID, SYNAPSE_TABLE_NAME)).thenReturn(SYNAPSE_TABLE_ID);
+
+        // column list from Synapse needs column name (because we check for it) and column ID (because we use it
+        ColumnModel serverSideColumn = new ColumnModel();
+        serverSideColumn.setName(SynapseStatusTableHelper.COLUMN_NAME_UPLOAD_DATE);
+        serverSideColumn.setId(COLUMN_ID);
+        when(mockSynapseHelper.getColumnModelsForTableWithRetry(SYNAPSE_TABLE_ID)).thenReturn(ImmutableList.of(
+                serverSideColumn));
+
+        // set up helper
+        SynapseStatusTableHelper statusTableHelper = new SynapseStatusTableHelper();
+        statusTableHelper.setManager(mockManager);
+        statusTableHelper.setSynapseHelper(mockSynapseHelper);
+
+        // execute
+        // initial call creates the table
+        ExportTask task1 = mock(ExportTask.class);
+        when(task1.getExporterDate()).thenReturn(LocalDate.parse("2016-03-06"));
+        statusTableHelper.initTableAndWriteStatus(task1, STUDY_ID);
+
+        // verify we created the table
+        verify(mockSynapseHelper, times(1)).createTableWithColumnsAndAcls(SynapseStatusTableHelper.COLUMN_LIST,
+                DATA_ACCESS_TEAM_ID, SYNAPSE_PRINCIPAL_ID, SYNAPSE_PROJECT_ID, SYNAPSE_TABLE_NAME);
+        verify(mockManager, times(1)).setSynapseTableIdToDdb(task1, SynapseHelper.DDB_TABLE_SYNAPSE_META_TABLES,
+                SynapseHelper.DDB_KEY_TABLE_NAME, SYNAPSE_TABLE_NAME, SYNAPSE_TABLE_ID);
+
+        // verify write to Synapse
+        ArgumentCaptor<PartialRowSet> rowSetCaptor1 = ArgumentCaptor.forClass(PartialRowSet.class);
+        verify(mockSynapseHelper, times(1)).appendRowsToTableWithRetry(rowSetCaptor1.capture(), eq(SYNAPSE_TABLE_ID));
+
+        PartialRowSet rowSet1 = rowSetCaptor1.getValue();
+        assertEquals(rowSet1.getTableId(), SYNAPSE_TABLE_ID);
+
+        List<PartialRow> rowList1 = rowSet1.getRows();
+        assertEquals(rowList1.size(), 1);
+
+        PartialRow row1 = rowList1.get(0);
+        Map<String, String> rowValueMap1 = row1.getValues();
+        assertEquals(rowValueMap1.size(), 1);
+        assertEquals(rowValueMap1.get(COLUMN_ID), "2016-03-06");
+
+        // second call, tables already exist
+        ExportTask task2 = mock(ExportTask.class);
+        when(task2.getExporterDate()).thenReturn(LocalDate.parse("2016-03-07"));
+        statusTableHelper.initTableAndWriteStatus(task2, STUDY_ID);
+
+        // Verify we only tried to create the table once. (verify() is cumulative, so times(1) means we verified it the
+        // first time around, and it didn't happen again.)
+        verify(mockSynapseHelper, times(1)).createTableWithColumnsAndAcls(anyListOf(ColumnModel.class), anyLong(),
+                anyLong(), anyString(), anyString());
+        verify(mockManager, times(1)).setSynapseTableIdToDdb(any(ExportTask.class), anyString(), anyString(),
+                anyString(), anyString());
+
+        // Verify a second write to Synapse. (Again, verify() is cumulative.)
+        ArgumentCaptor<PartialRowSet> rowSetCaptor2 = ArgumentCaptor.forClass(PartialRowSet.class);
+        verify(mockSynapseHelper, times(2)).appendRowsToTableWithRetry(rowSetCaptor2.capture(), eq(SYNAPSE_TABLE_ID));
+
+        PartialRowSet rowSet2 = rowSetCaptor2.getValue();
+        assertEquals(rowSet2.getTableId(), SYNAPSE_TABLE_ID);
+
+        List<PartialRow> rowList2 = rowSet2.getRows();
+        assertEquals(rowList2.size(), 1);
+
+        PartialRow row2 = rowList2.get(0);
+        Map<String, String> rowValueMap2 = row2.getValues();
+        assertEquals(rowValueMap2.size(), 1);
+        assertEquals(rowValueMap2.get(COLUMN_ID), "2016-03-07");
+    }
+}

--- a/src/test/java/org/sagebionetworks/bridge/exporter/worker/ExportTaskTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/worker/ExportTaskTest.java
@@ -8,6 +8,7 @@ import static org.testng.Assert.assertTrue;
 import java.io.File;
 import java.io.PrintWriter;
 import java.util.Queue;
+import java.util.Set;
 import java.util.concurrent.Future;
 
 import com.google.common.collect.ImmutableList;
@@ -118,6 +119,20 @@ public class ExportTaskTest {
         assertSame(taskQueue.remove(), mockFooFuture);
         assertSame(taskQueue.remove(), mockBarFuture);
         assertTrue(taskQueue.isEmpty());
+    }
+
+    @Test
+    public void studyIdSet() {
+        ExportTask task = createTask();
+        task.addStudyId("foo");
+        task.addStudyId("bar");
+        task.addStudyId("baz");
+
+        Set<String> studyIdSet = task.getStudyIdSet();
+        assertEquals(studyIdSet.size(), 3);
+        assertTrue(studyIdSet.contains("foo"));
+        assertTrue(studyIdSet.contains("bar"));
+        assertTrue(studyIdSet.contains("baz"));
     }
 
     private static ExportTask createTask() {


### PR DESCRIPTION
Two changes:
1. At the end of export, Bridge-EX will now write to a "status table" in each Synapse project (creating the table if it doesn't exist). The sole purpose of this table is to signal any automated jobs to start (notably, Chris Bare's data analysis that's being consumed for mPower viz). As such, the only thing each row in this table contains is the date of the last Bridge-EX execution for that study. (Example, Bridge-EX runs on 2016-03-07, processes data for 2016-03-06, writes 2016-03-07 to the status table.)
2. Moved table creation code to SynapseHelper. It's no longer a Handler exclusive thing, so we're moving it further down the stack.
# File-By-File Overview
- AppVersionExportHandler - SynapseMetaTables is now shared between AppVersion and Status tables, so we're moving these constants to SynapseHelper.
- SynapseExportHandler - Refactoring a lot of the logic to shared classes. The logic for writing to the DDB table map is now in ExportWorkerManager, since it depends heavily on stuff that's already there. Creating columns, tables, and ACLs is moved to SynapseHelper. (The diff is a bit messy. get/setSynapseTableIdFromDdb is moved to ExportWorkerManager, createTable() is the replacement for getColumnNameListForNewTable().)

This has an interesting side effect that creating tables now returns the Synapse table ID instead of the list of column IDs, so we'll need to make another call Synapse to get the column IDs back. This isn't a big deal, since it only happens when a new table is created, which is very rare. (Part of this includes renaming getColumnNameListForExistingTable() to simply getColumnNameListForTable(), since it will be called for both.)
- SynapseHelper - Added createTableWithColumnsAndAcls(). This encapsulates common operations around table creation, notably creating column models and setting ACLs. There's no retry annotation on this method because the underlying methods have retries, and retries on multiple layers generally lead to weird things happening.
- SynapseStatusTableHelper - Helper to write to Synapse Status table, or create it if necessary. The main method calls two private helper methods:
1. createStatusTable(), which creates the table (calling through to SynapseHelper), then writes the table ID to DDB (calling through to ExportWorkerManager).
2. writeStatus(), which calls Synapse to get the column IDs, then writes a single row with a single column to the Status table. There's some validation here in case the Status table is malformed. It's not future-proof, but we can make it future-proof if/when we decide to expand the usage of the Status table.
- ExportTask - Each task now needs to know which study IDs it operated on, so we can write to the appropriate Status tables. ExportTask already keeps track of task state (TSVs, outstanding tasks), so adding a set of Study IDs to it should be a no-brainer.
- ExportWorkerManager - 3 major changes here:
1. Moving get/setSynapseTableIdFromDdb from SynapseExportHandler to here, so that it can be used by SynapseStatusTableHelper. (Note that there is a circular dependency between ExportWorkerManager and SynapseStatusTableHelper.) 
2. In addSubtaskForRecord() (which is called for every Health Data Record), we add the study ID to the task. As previously noted, this is to keep track of which Status tables to update.
3. In endOfStream() (which is called at the end of every export task), after we're done uploading to all health data tables and all app version tables, we get the set of study IDs and call SynapseStatusTableHelper to write to the respective status tables. We do this in a try-catch so one failure to write to a status table doesn't fail the whole job.

Plus 2 minor changes:
1. Remove "final" from some of these methods. These are getters with no side effect, so there shouldn't be a risk of removing final. Plus, removing final allows us to mock/spy these methods if needed.
2. Remove getDdbClient(). Since get/setSynapseTableFromDdb was removed from SynapseExportHandler, this getter is no longer needed. (If in the future, it is needed, it's trivial to add it back.)
# Testing Done
- Added and updated unit tests.
- mvn verify (unit tests, jacoco coverage checks, findbugs)
- manual tests: (1) Tested in a blank Synapse project to make sure all tables were created properly. (2) Tested again in the same project to make sure we can write to existing Synapse projects.
