### PR TITLE
Strip HTML from user data (externalID, appVersion, phoneInfo, health data)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,11 @@
             <version>1.8.7</version>
         </dependency>
         <dependency>
+            <groupId>org.jsoup</groupId>
+            <artifactId>jsoup</artifactId>
+            <version>1.8.3</version>
+        </dependency>
+        <dependency>
             <groupId>org.sagebionetworks</groupId>
             <artifactId>bridge-base</artifactId>
             <version>1.2</version>

--- a/src/test/java/org/sagebionetworks/bridge/exporter/util/BridgeExporterUtilTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/util/BridgeExporterUtilTest.java
@@ -82,15 +82,21 @@ public class BridgeExporterUtilTest {
     }
 
     @Test
-    public void sanitizeStringWhitespace() {
-        String out = BridgeExporterUtil.sanitizeString("   ", 100, "dummy-record");
-        assertEquals(out, "   ");
-    }
-
-    @Test
     public void sanitizeStringPassthrough() {
         String out = BridgeExporterUtil.sanitizeString("lorem ipsum", 100, "dummy-record");
         assertEquals(out, "lorem ipsum");
+    }
+
+    @Test
+    public void sanitizeStringRemoveHtml() {
+        String out = BridgeExporterUtil.sanitizeString("<b>bold text</b>", 100, "dummy-record");
+        assertEquals(out, "bold text");
+    }
+
+    @Test
+    public void sanitizeStringRemovePartialHtml() {
+        String out = BridgeExporterUtil.sanitizeString("imbalanced</i> <p>tags", 100, "dummy-record");
+        assertEquals(out, "imbalanced tags");
     }
 
     @Test


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/BRIDGE-1028

It's fairly easy to construct an upload with HTML. While Synapse properly escapes this so the HTML is shown as plain text to the researcher, there's nothing preventing the researcher from downloading the data, embedding it in a webpage, and causing bad things to happen later down the pipeline.

We're going to pre-emptively prevent this situation by stripping out all HTML from user input.

Testing done:
- mvn verify (unit tests, jacoco coverage, findbugs)
- manual test by contructing an upload with these properties and verifying the HTML gets stripped out before hitting Synapse
