### PR TITLE
Logentries Java Agent in .ebextensions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,12 +54,6 @@
             <version>0.22.1</version>
         </dependency>
         <dependency>
-            <groupId>com.logentries</groupId>
-            <artifactId>logentries-appender</artifactId>
-            <version>RELEASE</version>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
             <version>2.9.1</version>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -6,20 +6,8 @@
         </encoder>
     </appender>
 
-    <!-- To test this locally, run mvn spring-boot:run -Dlogentries.token=[token] -->
-    <appender name="LOGENTRIES" class="com.logentries.logback.LogentriesAppender">
-        <Debug>False</Debug>
-        <Token>${logentries.token}</Token>
-        <Ssl>False</Ssl>
-        <facility>USER</facility>
-        <layout>
-            <pattern>%d{ISO8601} %-5p [%t] %logger - %message%n%xException%n%mdc</pattern>
-        </layout>
-    </appender>
-
     <root level="WARN">
         <appender-ref ref="STDOUT" />
-        <appender-ref ref="LOGENTRIES" />
     </root>
 
     <logger name="org.sagebionetworks.bridge.exporter" level="INFO" />

--- a/src/main/webapp/.ebextensions/logentries.config
+++ b/src/main/webapp/.ebextensions/logentries.config
@@ -26,7 +26,8 @@ commands:
 container_commands:
   02-create-logentries-config:
     command: |
-      rm $LOGENTRIES_CONFIG_PATH
+      mkdir -p /etc/le
+      rm -f $LOGENTRIES_CONFIG_PATH
       echo [Main] > $LOGENTRIES_CONFIG_PATH
       echo user-key = $LOGENTRIES_USER_KEY >> $LOGENTRIES_CONFIG_PATH
       echo pull-server-side-config=False >> $LOGENTRIES_CONFIG_PATH

--- a/src/main/webapp/.ebextensions/logentries.config
+++ b/src/main/webapp/.ebextensions/logentries.config
@@ -16,20 +16,6 @@ files:
       gpgkey=http://rep.logentries.com/RPM-GPG-KEY-logentries
     encoding: plain
 
-  "/etc/le/config" :
-    mode: "000755"
-    owner: root
-    group: root
-    content: |
-      [Main]
-      user-key = ACCOUNT_KEY
-      pull-server-side-config=False
-
-      [Application name]
-      path = /path/to/log/file
-      token = MY_TOKEN
-    encoding: plain
-
 commands:
   01-update-yum:
     command: yum update

--- a/src/main/webapp/.ebextensions/logentries.config
+++ b/src/main/webapp/.ebextensions/logentries.config
@@ -17,13 +17,14 @@ files:
     encoding: plain
 
 commands:
-  01-update-yum:
-    command: yum update
-  02-install-logentries:
-    command: yum install logentries-daemon -y
+  01-install-logentries:
+    command: |
+      yum update
+      yum install logentries -y
+      yum install logentries-daemon -y
 
 container_commands:
-  03-create-logentries-config:
+  02-create-logentries-config:
     command: |
       rm $LOGENTRIES_CONFIG_PATH
       echo [Main] > $LOGENTRIES_CONFIG_PATH
@@ -33,5 +34,5 @@ container_commands:
       echo [name] >> $LOGENTRIES_CONFIG_PATH
       echo path = /var/log/tomcat8/catalina.out >> $LOGENTRIES_CONFIG_PATH
       echo destination = Bridge-EX2-$ENV/Bridge-EX2-$ENV >> $LOGENTRIES_CONFIG_PATH
-  04-restart-logentries:
-    command: service logentries start
+  03-restart-logentries:
+    command: /sbin/service logentries start

--- a/src/main/webapp/.ebextensions/logentries.config
+++ b/src/main/webapp/.ebextensions/logentries.config
@@ -1,0 +1,51 @@
+option_settings:
+  - option_name: LOGENTRIES_CONFIG_PATH
+    value: /etc/le/config
+
+files:
+  "/etc/yum.repos.d/logentries.repo":
+    mode: "000664"
+    owner: root
+    group: root
+    content: |
+      [logentries]
+      name=Logentries repo
+      enabled=1
+      metadata_expire=1d
+      baseurl=http://rep.logentries.com/amazonlatest/\$basearch
+      gpgkey=http://rep.logentries.com/RPM-GPG-KEY-logentries
+    encoding: plain
+
+  "/etc/le/config" :
+    mode: "000755"
+    owner: root
+    group: root
+    content: |
+      [Main]
+      user-key = ACCOUNT_KEY
+      pull-server-side-config=False
+
+      [Application name]
+      path = /path/to/log/file
+      token = MY_TOKEN
+    encoding: plain
+
+commands:
+  01-update-yum:
+    command: yum update
+  02-install-logentries:
+    command: yum install logentries-daemon -y
+
+container_commands:
+  03-create-logentries-config:
+    command: |
+      rm $LOGENTRIES_CONFIG_PATH
+      echo [Main] > $LOGENTRIES_CONFIG_PATH
+      echo user-key = $LOGENTRIES_USER_KEY >> $LOGENTRIES_CONFIG_PATH
+      echo pull-server-side-config=False >> $LOGENTRIES_CONFIG_PATH
+      echo >> $LOGENTRIES_CONFIG_PATH
+      echo [name] >> $LOGENTRIES_CONFIG_PATH
+      echo path = /var/log/tomcat8/catalina.out >> $LOGENTRIES_CONFIG_PATH
+      echo destination = Bridge-EX2-$ENV/Bridge-EX2-$ENV >> $LOGENTRIES_CONFIG_PATH
+  04-restart-logentries:
+    command: service logentries start


### PR DESCRIPTION
Logentries support recommends switching from the Logback Appender to the Java Agent for more robust logging.

Testing done: mvn package to build the war file, deployed it to BridgeEX-Dev, and verified that logging works.

Tested both on a clean box and on a box that already has Logentries config.
