### PR TITLE
automatically create new columns when the schema changes

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/exporter/handler/SynapseExportHandler.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/handler/SynapseExportHandler.java
@@ -9,14 +9,19 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
 
 import com.amazonaws.services.dynamodbv2.document.Item;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Sets;
 import org.sagebionetworks.client.exceptions.SynapseException;
 import org.sagebionetworks.repo.model.table.ColumnModel;
 import org.sagebionetworks.repo.model.table.ColumnType;
+import org.sagebionetworks.repo.model.table.TableEntity;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -155,53 +160,129 @@ public abstract class SynapseExportHandler extends ExportHandler {
     // Gets the column name list from Synapse. If the Synapse table doesn't exist, this will create it. This is called
     // when initializing the TSV for a task.
     private List<String> getColumnNameList(ExportTask task) throws BridgeExporterException, SynapseException {
+        // Construct column definition list. Merge COMMON_COLUMN_LIST with getSynapseTableColumnList.
+        List<ColumnModel> columnDefList = new ArrayList<>();
+        columnDefList.addAll(COMMON_COLUMN_LIST);
+        columnDefList.addAll(getSynapseTableColumnList());
+
+        // Create or update table if necessary. Get the column list from the create() or update() call to make sure we
+        // have a column list that matches the Synapse table.
+        List<ColumnModel> serverColumnList;
         String synapseTableId = getManager().getSynapseTableIdFromDdb(task, getDdbTableName(), getDdbTableKeyName(),
                 getDdbTableKeyValue());
         if (synapseTableId == null) {
-            synapseTableId = createNewTable(task);
+            serverColumnList = createTableAndGetColumnList(task, columnDefList);
+        } else {
+            serverColumnList = updateTableAndGetColumnList(synapseTableId, columnDefList);
         }
-        return getColumnNameListForTable(synapseTableId);
+
+        // Extract column names from column models
+        List<String> columnNameList = new ArrayList<>();
+        //noinspection Convert2streamapi
+        for (ColumnModel oneServerColumn : serverColumnList) {
+            columnNameList.add(oneServerColumn.getName());
+        }
+        return columnNameList;
     }
 
-    // Helper method to create the new Synapse table. Returns the Synapse table ID.
-    private String createNewTable(ExportTask task) throws BridgeExporterException,
-            SynapseException {
+    // Helper method to create the new Synapse table. Returns the list of columns, with column IDs.
+    private List<ColumnModel> createTableAndGetColumnList(ExportTask task, List<ColumnModel> columnDefList)
+            throws BridgeExporterException, SynapseException {
         ExportWorkerManager manager = getManager();
-
-        // Construct column definition list. Merge COMMON_COLUMN_LIST with getSynapseTableColumnList.
-        List<ColumnModel> columnList = new ArrayList<>();
-        columnList.addAll(COMMON_COLUMN_LIST);
-        columnList.addAll(getSynapseTableColumnList());
+        SynapseHelper synapseHelper = manager.getSynapseHelper();
 
         // Delegate table creation to SynapseHelper.
         long dataAccessTeamId = manager.getDataAccessTeamIdForStudy(getStudyId());
         long principalId = manager.getSynapsePrincipalId();
         String projectId = manager.getSynapseProjectIdForStudyAndTask(getStudyId(), task);
         String tableName = getDdbTableKeyValue();
-        String synapseTableId = manager.getSynapseHelper().createTableWithColumnsAndAcls(columnList, dataAccessTeamId,
+        String synapseTableId = synapseHelper.createTableWithColumnsAndAcls(columnDefList, dataAccessTeamId,
                 principalId, projectId, tableName);
 
         // write back to DDB table
         manager.setSynapseTableIdToDdb(task, getDdbTableName(), getDdbTableKeyName(), getDdbTableKeyValue(),
                 synapseTableId);
 
-        return synapseTableId;
+        // Get the column list.
+        return synapseHelper.getColumnModelsForTableWithRetry(synapseTableId);
     }
 
-    // Helper method to get the column name list for a Synapse table. This queries the column model list from Synapse.
-    private List<String> getColumnNameListForTable(String synapseTableId) throws SynapseException {
-        // Get columns from Synapse
+    // Helper method to detect when a schema changes and updates the Synapse table accordingly. Will reject schema
+    // changes that delete or modify columns. Optimized so if no columns were inserted, it won't modify the table.
+    // Returns the list of columns that matches what's on Synapse.
+    private List<ColumnModel> updateTableAndGetColumnList(String synapseTableId, List<ColumnModel> columnDefList)
+            throws SynapseException {
         ExportWorkerManager manager = getManager();
         SynapseHelper synapseHelper = manager.getSynapseHelper();
-        List<ColumnModel> columnModelList = synapseHelper.getColumnModelsForTableWithRetry(synapseTableId);
 
-        // Extract column names from column models
-        List<String> columnNameList = new ArrayList<>();
-        //noinspection Convert2streamapi
-        for (ColumnModel oneColumnModel : columnModelList) {
-            columnNameList.add(oneColumnModel.getName());
+        // Get existing columns from table.
+        List<ColumnModel> existingColumnList = synapseHelper.getColumnModelsForTableWithRetry(synapseTableId);
+
+        // Compute the columns that were added, deleted, and kept. Use tree maps so logging will show a stable message.
+        Map<String, ColumnModel> existingColumnsByName = new TreeMap<>();
+        for (ColumnModel oneExistingColumn : existingColumnList) {
+            existingColumnsByName.put(oneExistingColumn.getName(), oneExistingColumn);
         }
-        return columnNameList;
+
+        Map<String, ColumnModel> columnDefsByName = new TreeMap<>();
+        for (ColumnModel oneColumnDef : columnDefList) {
+            columnDefsByName.put(oneColumnDef.getName(), oneColumnDef);
+        }
+
+        Set<String> addedColumnNameSet = Sets.difference(columnDefsByName.keySet(), existingColumnsByName.keySet());
+        Set<String> deletedColumnNameSet = Sets.difference(existingColumnsByName.keySet(), columnDefsByName.keySet());
+        Set<String> keptColumnNameSet = Sets.intersection(existingColumnsByName.keySet(), columnDefsByName.keySet());
+
+        // Were columns deleted? If so, log an error and shortcut. (Don't modify the table.)
+        boolean shouldUpdateTable = true;
+        if (!deletedColumnNameSet.isEmpty()) {
+            LOG.error("Table " + getDdbTableKeyValue() + " has deleted columns: " +
+                    BridgeExporterUtil.COMMA_SPACE_JOINER.join(deletedColumnNameSet));
+            shouldUpdateTable = false;
+        }
+
+        // Similarly, were any columns changed?
+        Set<String> modifiedColumnNameSet = new TreeSet<>();
+        for (String oneKeptColumnName : keptColumnNameSet) {
+            // Validate that column type and max size are the same. We can't use .equals() because ID is definitely
+            // different.
+            ColumnModel existingColumn = existingColumnsByName.get(oneKeptColumnName);
+            ColumnModel columnDef = columnDefsByName.get(oneKeptColumnName);
+            if (existingColumn.getColumnType() != columnDef.getColumnType() ||
+                    !Objects.equals(existingColumn.getMaximumSize(), columnDef.getMaximumSize())) {
+                modifiedColumnNameSet.add(oneKeptColumnName);
+            }
+        }
+        if (!modifiedColumnNameSet.isEmpty()) {
+            LOG.error("Table " + getDdbTableKeyValue() + " has modified columns: " +
+                    BridgeExporterUtil.COMMA_SPACE_JOINER.join(modifiedColumnNameSet));
+            shouldUpdateTable = false;
+        }
+
+        // Optimization: Were any columns added?
+        if (addedColumnNameSet.isEmpty()) {
+            shouldUpdateTable = false;
+        }
+
+        if (!shouldUpdateTable) {
+            return existingColumnList;
+        }
+
+        // Make sure the columns have been created / get column IDs.
+        List<ColumnModel> createdColumnList = synapseHelper.createColumnModelsWithRetry(columnDefList);
+
+        // Update table.
+        List<String> colIdList = new ArrayList<>();
+        //noinspection Convert2streamapi
+        for (ColumnModel oneCreatedColumn : createdColumnList) {
+            colIdList.add(oneCreatedColumn.getId());
+        }
+
+        TableEntity table = synapseHelper.getTableWithRetry(synapseTableId);
+        table.setColumnIds(colIdList);
+        synapseHelper.updateTableWithRetry(table);
+
+        return createdColumnList;
     }
 
     // Helper method to get row values that are common across all Synapse tables and handlers.

--- a/src/main/java/org/sagebionetworks/bridge/exporter/synapse/SynapseHelper.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/synapse/SynapseHelper.java
@@ -578,6 +578,21 @@ public class SynapseHelper {
     }
 
     /**
+     * Updates a Synapse table and returns the updated table. This is a retry wrapper.
+     *
+     * @param table
+     *         table to update
+     * @return updated table
+     * @throws SynapseException
+     *         if the Synapse call fails
+     */
+    @RetryOnFailure(attempts = 5, delay = 100, unit = TimeUnit.MILLISECONDS, types = SynapseException.class,
+            randomize = false)
+    public TableEntity updateTableWithRetry(TableEntity table) throws SynapseException {
+        return synapseClient.putEntity(table);
+    }
+
+    /**
      * Starts applying an uploaded TSV file handle to a Synapse table. This is a retry wrapper.
      *
      * @param tableId

--- a/src/main/java/org/sagebionetworks/bridge/exporter/util/BridgeExporterUtil.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/util/BridgeExporterUtil.java
@@ -4,6 +4,7 @@ import java.util.Set;
 
 import com.amazonaws.services.dynamodbv2.document.Item;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableSetMultimap;
 import org.jsoup.Jsoup;
 import org.jsoup.safety.Whitelist;
@@ -15,6 +16,8 @@ import org.sagebionetworks.bridge.schema.UploadSchemaKey;
 /** Various static utility methods that don't neatly fit anywhere else. */
 public class BridgeExporterUtil {
     private static final Logger LOG = LoggerFactory.getLogger(BridgeExporterUtil.class);
+
+    public static final Joiner COMMA_SPACE_JOINER = Joiner.on(", ").useForNull("");
 
     private static final ImmutableSetMultimap<UploadSchemaKey, String> SCHEMA_FIELDS_TO_CONVERT;
     static {

--- a/src/test/java/org/sagebionetworks/bridge/exporter/handler/SynapseExportHandlerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/handler/SynapseExportHandlerTest.java
@@ -352,6 +352,10 @@ public class SynapseExportHandlerTest {
         assertTrue(mockFileHelper.isEmpty());
     }
 
+    public static ExportSubtask makeSubtask(ExportTask parentTask) throws IOException {
+        return makeSubtask(parentTask, "{}");
+    }
+
     public static ExportSubtask makeSubtask(ExportTask parentTask, String key, String value) throws IOException {
         return makeSubtask(parentTask, "{\"" + key + "\":\"" + value + "\"}");
     }

--- a/src/test/java/org/sagebionetworks/bridge/exporter/handler/SynapseExportHandlerUpdateTableTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/handler/SynapseExportHandlerUpdateTableTest.java
@@ -1,0 +1,322 @@
+package org.sagebionetworks.bridge.exporter.handler;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.notNull;
+import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.mockito.ArgumentCaptor;
+import org.sagebionetworks.repo.model.table.ColumnModel;
+import org.sagebionetworks.repo.model.table.ColumnType;
+import org.sagebionetworks.repo.model.table.TableEntity;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import org.sagebionetworks.bridge.config.Config;
+import org.sagebionetworks.bridge.exporter.metrics.Metrics;
+import org.sagebionetworks.bridge.exporter.synapse.SynapseHelper;
+import org.sagebionetworks.bridge.exporter.util.TestUtil;
+import org.sagebionetworks.bridge.exporter.worker.ExportSubtask;
+import org.sagebionetworks.bridge.exporter.worker.ExportTask;
+import org.sagebionetworks.bridge.exporter.worker.ExportWorkerManager;
+import org.sagebionetworks.bridge.file.InMemoryFileHelper;
+
+public class SynapseExportHandlerUpdateTableTest {
+    private List<String> expectedColIdList;
+    private SynapseHelper mockSynapseHelper;
+    private ExportTask task;
+    private byte[] tsvBytes;
+
+    @BeforeMethod
+    public void before() {
+        // clear vars, because TestNG doesn't always do that
+        expectedColIdList = null;
+        tsvBytes = null;
+    }
+
+    private void setup(SynapseExportHandler handler, List<ColumnModel> existingColumnList) throws Exception {
+        // This needs to be done first, because lots of stuff reference this, even while we're setting up mocks.
+        handler.setStudyId(SynapseExportHandlerTest.TEST_STUDY_ID);
+
+        // mock config
+        Config mockConfig = mock(Config.class);
+        when(mockConfig.get(ExportWorkerManager.CONFIG_KEY_EXPORTER_DDB_PREFIX)).thenReturn(
+                SynapseExportHandlerTest.DUMMY_DDB_PREFIX);
+        when(mockConfig.getInt(ExportWorkerManager.CONFIG_KEY_SYNAPSE_PRINCIPAL_ID))
+                .thenReturn(SynapseExportHandlerTest.TEST_SYNAPSE_PRINCIPAL_ID);
+        when(mockConfig.getInt(ExportWorkerManager.CONFIG_KEY_WORKER_MANAGER_PROGRESS_REPORT_PERIOD)).thenReturn(250);
+
+        // mock file helper
+        InMemoryFileHelper mockFileHelper = new InMemoryFileHelper();
+        File tmpDir = mockFileHelper.createTempDir();
+
+        // mock Synapse helper
+        mockSynapseHelper = mock(SynapseHelper.class);
+
+        // mock get column model list
+        when(mockSynapseHelper.getColumnModelsForTableWithRetry(SynapseExportHandlerTest.TEST_SYNAPSE_TABLE_ID))
+                .thenReturn(existingColumnList);
+
+        // mock create column model list - We only care about the names and IDs for the created columns.
+        List<ColumnModel> columnDefList = new ArrayList<>();
+        columnDefList.addAll(SynapseExportHandler.COMMON_COLUMN_LIST);
+        columnDefList.addAll(handler.getSynapseTableColumnList());
+
+        List<ColumnModel> createdColumnList = new ArrayList<>();
+        expectedColIdList = new ArrayList<>();
+        for (ColumnModel oneColumnDef : columnDefList) {
+            String colName = oneColumnDef.getName();
+            String colId = colName + "-id";
+            expectedColIdList.add(colId);
+
+            ColumnModel createdColumn = new ColumnModel();
+            createdColumn.setName(colName);
+            createdColumn.setId(colId);
+            createdColumnList.add(createdColumn);
+        }
+
+        when(mockSynapseHelper.createColumnModelsWithRetry(columnDefList)).thenReturn(createdColumnList);
+
+        // mock get table - just a dummy table that we can fill in
+        when(mockSynapseHelper.getTableWithRetry(SynapseExportHandlerTest.TEST_SYNAPSE_TABLE_ID)).thenReturn(
+                new TableEntity());
+
+        // mock upload the TSV and capture the upload
+        when(mockSynapseHelper.uploadTsvFileToTable(eq(SynapseExportHandlerTest.TEST_SYNAPSE_PROJECT_ID),
+                eq(SynapseExportHandlerTest.TEST_SYNAPSE_TABLE_ID), notNull(File.class))).thenAnswer(invocation -> {
+            // on cleanup, the file is destroyed, so we need to intercept that file now
+            File tsvFile = invocation.getArgumentAt(2, File.class);
+            tsvBytes = mockFileHelper.getBytes(tsvFile);
+
+            // we processed 1 rows
+            return 1;
+        });
+
+        // setup manager - This is mostly used to get helper objects.
+        ExportWorkerManager manager = spy(new ExportWorkerManager());
+        manager.setConfig(mockConfig);
+        manager.setFileHelper(mockFileHelper);
+        manager.setSynapseHelper(mockSynapseHelper);
+        handler.setManager(manager);
+
+
+        // set up task
+        task = new ExportTask.Builder().withExporterDate(SynapseExportHandlerTest.DUMMY_REQUEST_DATE)
+                .withMetrics(new Metrics()).withRequest(SynapseExportHandlerTest.DUMMY_REQUEST).withTmpDir(tmpDir)
+                .build();
+
+        // spy getSynapseProjectId and getDataAccessTeam
+        // These calls through to a bunch of stuff (which we test in ExportWorkerManagerTest), so to simplify our test,
+        // we just use a spy here.
+        doReturn(SynapseExportHandlerTest.TEST_SYNAPSE_PROJECT_ID).when(manager).getSynapseProjectIdForStudyAndTask(
+                eq(SynapseExportHandlerTest.TEST_STUDY_ID), same(task));
+        doReturn(SynapseExportHandlerTest.TEST_SYNAPSE_DATA_ACCESS_TEAM_ID).when(manager).getDataAccessTeamIdForStudy(
+                SynapseExportHandlerTest.TEST_STUDY_ID);
+
+        // Similarly, spy get/setSynapseTableIdFromDDB.
+        doReturn(SynapseExportHandlerTest.TEST_SYNAPSE_TABLE_ID).when(manager).getSynapseTableIdFromDdb(task,
+                handler.getDdbTableName(), handler.getDdbTableKeyName(), handler.getDdbTableKeyValue());
+    }
+
+    // Subclass TestSynapseHandler and add a few more fields.
+    private static class UpdateTestSynapseHandler extends TestSynapseHandler {
+        @Override
+        protected List<ColumnModel> getSynapseTableColumnList() {
+            return ImmutableList.of(makeColumn("modify-this"), makeColumn("add-this"), makeColumn("swap-this-A"),
+                    makeColumn("swap-this-B"));
+        }
+
+        // For test purposes, this will always match the schema returned by getSynapseTableColumnList. The tests will
+        // validate how this interacts with the "existing" table and updates (or lack thereof).
+        @Override
+        protected Map<String, String> getTsvRowValueMap(ExportSubtask subtask) throws IOException {
+            return new ImmutableMap.Builder<String, String>().put("modify-this", "modify-this value")
+                    .put("add-this", "add-this value") .put("swap-this-A", "swap-this-A value")
+                    .put("swap-this-B", "swap-this-B value").build();
+        }
+    }
+
+    @Test
+    public void rejectDelete() throws Exception {
+        // Existing columns has "delete-this" (rejected). Handler has "add-this" (without which we wouldn't trigger the
+        // update table code anyway).
+        List<ColumnModel> existingColumnList = new ArrayList<>();
+        existingColumnList.addAll(SynapseExportHandler.COMMON_COLUMN_LIST);
+        existingColumnList.add(makeColumn("delete-this"));
+        existingColumnList.add(makeColumn("modify-this"));
+        existingColumnList.add(makeColumn("swap-this-A"));
+        existingColumnList.add(makeColumn("swap-this-B"));
+
+        // setup
+        SynapseExportHandler handler = new UpdateTestSynapseHandler();
+        setup(handler, existingColumnList);
+
+        // execute
+        handler.handle(SynapseExportHandlerTest.makeSubtask(task, "{}"));
+        handler.uploadToSynapseForTask(task);
+
+        // validate tsv file
+        List<String> tsvLineList = TestUtil.bytesToLines(tsvBytes);
+        assertEquals(tsvLineList.size(), 2);
+        SynapseExportHandlerTest.validateTsvHeaders(tsvLineList.get(0), "delete-this", "modify-this", "swap-this-A",
+                "swap-this-B");
+        SynapseExportHandlerTest.validateTsvRow(tsvLineList.get(1), "", "modify-this value", "swap-this-A value",
+                "swap-this-B value");
+
+        // verify we did not update the table
+        verify(mockSynapseHelper, never()).updateTableWithRetry(any());
+    }
+
+    @Test
+    public void rejectModifyType() throws Exception {
+        // Modify column type.
+        List<ColumnModel> existingColumnList = new ArrayList<>();
+        existingColumnList.addAll(SynapseExportHandler.COMMON_COLUMN_LIST);
+
+        ColumnModel modifiedTypeColumn = new ColumnModel();
+        modifiedTypeColumn.setName("modify-this");
+        modifiedTypeColumn.setColumnType(ColumnType.INTEGER);
+        existingColumnList.add(modifiedTypeColumn);
+
+        existingColumnList.add(makeColumn("swap-this-A"));
+        existingColumnList.add(makeColumn("swap-this-B"));
+
+        // setup
+        SynapseExportHandler handler = new UpdateTestSynapseHandler();
+        setup(handler, existingColumnList);
+
+        // execute
+        handler.handle(SynapseExportHandlerTest.makeSubtask(task, "{}"));
+        handler.uploadToSynapseForTask(task);
+
+        // validate tsv file
+        List<String> tsvLineList = TestUtil.bytesToLines(tsvBytes);
+        assertEquals(tsvLineList.size(), 2);
+        SynapseExportHandlerTest.validateTsvHeaders(tsvLineList.get(0), "modify-this", "swap-this-A", "swap-this-B");
+        SynapseExportHandlerTest.validateTsvRow(tsvLineList.get(1), "modify-this value", "swap-this-A value",
+                "swap-this-B value");
+
+        // verify we did not update the table
+        verify(mockSynapseHelper, never()).updateTableWithRetry(any());
+    }
+
+    @Test
+    public void rejectModifySize() throws Exception {
+        // Modify column size.
+        List<ColumnModel> existingColumnList = new ArrayList<>();
+        existingColumnList.addAll(SynapseExportHandler.COMMON_COLUMN_LIST);
+
+        ColumnModel modifiedTypeColumn = new ColumnModel();
+        modifiedTypeColumn.setName("modify-this");
+        modifiedTypeColumn.setColumnType(ColumnType.STRING);
+        modifiedTypeColumn.setMaximumSize(42L);
+        existingColumnList.add(modifiedTypeColumn);
+
+        existingColumnList.add(makeColumn("swap-this-A"));
+        existingColumnList.add(makeColumn("swap-this-B"));
+
+        // setup
+        SynapseExportHandler handler = new UpdateTestSynapseHandler();
+        setup(handler, existingColumnList);
+
+        // execute
+        handler.handle(SynapseExportHandlerTest.makeSubtask(task, "{}"));
+        handler.uploadToSynapseForTask(task);
+
+        // validate tsv file
+        List<String> tsvLineList = TestUtil.bytesToLines(tsvBytes);
+        assertEquals(tsvLineList.size(), 2);
+        SynapseExportHandlerTest.validateTsvHeaders(tsvLineList.get(0), "modify-this", "swap-this-A", "swap-this-B");
+        SynapseExportHandlerTest.validateTsvRow(tsvLineList.get(1), "modify-this value", "swap-this-A value",
+                "swap-this-B value");
+
+        // verify we did not update the table
+        verify(mockSynapseHelper, never()).updateTableWithRetry(any());
+    }
+
+    @Test
+    public void dontUpdateIfNoAddedColumns() throws Exception {
+        // Swap the columns. "Add this" has already been added.
+        List<ColumnModel> existingColumnList = new ArrayList<>();
+        existingColumnList.addAll(SynapseExportHandler.COMMON_COLUMN_LIST);
+        existingColumnList.add(makeColumn("modify-this"));
+        existingColumnList.add(makeColumn("add-this"));
+        existingColumnList.add(makeColumn("swap-this-B"));
+        existingColumnList.add(makeColumn("swap-this-A"));
+
+        // setup
+        SynapseExportHandler handler = new UpdateTestSynapseHandler();
+        setup(handler, existingColumnList);
+
+        // execute
+        handler.handle(SynapseExportHandlerTest.makeSubtask(task, "{}"));
+        handler.uploadToSynapseForTask(task);
+
+        // validate tsv file - columns won't be swapped
+        List<String> tsvLineList = TestUtil.bytesToLines(tsvBytes);
+        assertEquals(tsvLineList.size(), 2);
+        SynapseExportHandlerTest.validateTsvHeaders(tsvLineList.get(0), "modify-this", "add-this", "swap-this-B",
+                "swap-this-A");
+        SynapseExportHandlerTest.validateTsvRow(tsvLineList.get(1), "modify-this value", "add-this value",
+                "swap-this-B value", "swap-this-A value");
+
+        // verify we did not update the table
+        verify(mockSynapseHelper, never()).updateTableWithRetry(any());
+    }
+
+    @Test
+    public void addAndSwapColumns() throws Exception {
+        // Existing columns does not have "add-this" and has swapped columns.
+        List<ColumnModel> existingColumnList = new ArrayList<>();
+        existingColumnList.addAll(SynapseExportHandler.COMMON_COLUMN_LIST);
+        existingColumnList.add(makeColumn("modify-this"));
+        existingColumnList.add(makeColumn("swap-this-B"));
+        existingColumnList.add(makeColumn("swap-this-A"));
+
+        // setup
+        SynapseExportHandler handler = new UpdateTestSynapseHandler();
+        setup(handler, existingColumnList);
+
+        // execute
+        handler.handle(SynapseExportHandlerTest.makeSubtask(task, "{}"));
+        handler.uploadToSynapseForTask(task);
+
+        // validate tsv file
+        List<String> tsvLineList = TestUtil.bytesToLines(tsvBytes);
+        assertEquals(tsvLineList.size(), 2);
+        SynapseExportHandlerTest.validateTsvHeaders(tsvLineList.get(0), "modify-this", "add-this", "swap-this-A",
+                "swap-this-B");
+        SynapseExportHandlerTest.validateTsvRow(tsvLineList.get(1), "modify-this value", "add-this value",
+                "swap-this-A value", "swap-this-B value");
+
+        // verify we did not update the table
+        ArgumentCaptor<TableEntity> tableCaptor = ArgumentCaptor.forClass(TableEntity.class);
+        verify(mockSynapseHelper).updateTableWithRetry(tableCaptor.capture());
+
+        TableEntity table = tableCaptor.getValue();
+        assertEquals(table.getColumnIds(), expectedColIdList);
+    }
+
+    private static ColumnModel makeColumn(String name) {
+        ColumnModel col = new ColumnModel();
+        col.setName(name);
+        col.setColumnType(ColumnType.STRING);
+        col.setMaximumSize(100L);
+        return col;
+    }
+}

--- a/src/test/java/org/sagebionetworks/bridge/exporter/synapse/SynapseHelperTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/synapse/SynapseHelperTest.java
@@ -227,6 +227,22 @@ public class SynapseHelperTest {
     }
 
     @Test
+    public void updateTable() throws Exception {
+        // mock Synapse Client - Assume put entity returns a separate output table.
+        SynapseClient mockSynapseClient = mock(SynapseClient.class);
+        TableEntity inputTable = new TableEntity();
+        TableEntity outputTable = new TableEntity();
+        when(mockSynapseClient.putEntity(inputTable)).thenReturn(outputTable);
+
+        SynapseHelper synapseHelper = new SynapseHelper();
+        synapseHelper.setSynapseClient(mockSynapseClient);
+
+        // execute and validate
+        TableEntity retVal = synapseHelper.updateTableWithRetry(inputTable);
+        assertSame(retVal, outputTable);
+    }
+
+    @Test
     public void uploadTsvStart() throws Exception {
         // mock Synapse Client
         SynapseClient mockSynapseClient = mock(SynapseClient.class);

--- a/src/test/java/org/sagebionetworks/bridge/exporter/worker/TsvInfoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/worker/TsvInfoTest.java
@@ -4,7 +4,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertSame;
+import static org.testng.Assert.fail;
 
 import java.io.File;
 import java.io.PrintWriter;
@@ -65,5 +67,32 @@ public class TsvInfoTest {
         tsvInfo.writeRow(new ImmutableMap.Builder<String, String>().put("foo", "realistic").put("bar", "lines")
                 .build());
         tsvInfo.flushAndCloseWriter();
+    }
+
+    @Test
+    public void initError() {
+        try {
+            TsvInfo.INIT_ERROR_TSV_INFO.checkInitAndThrow();
+            fail("expected exception");
+        } catch (BridgeExporterException ex) {
+            // expected exception
+        }
+
+        try {
+            TsvInfo.INIT_ERROR_TSV_INFO.writeRow(ImmutableMap.of());
+            fail("expected exception");
+        } catch (BridgeExporterException ex) {
+            // expected exception
+        }
+
+        try {
+            TsvInfo.INIT_ERROR_TSV_INFO.flushAndCloseWriter();
+            fail("expected exception");
+        } catch (BridgeExporterException ex) {
+            // expected exception
+        }
+
+        assertNull(TsvInfo.INIT_ERROR_TSV_INFO.getFile());
+        assertEquals(TsvInfo.INIT_ERROR_TSV_INFO.getLineCount(), 0);
     }
 }


### PR DESCRIPTION
This is needed to support mutable schemas. Bridge-EX will now compare the existing columns in a Synapse table against the column defs generated from a schema, and update the Synapse table accordingly if they are different. Has checks to prevent against column deletion and column modification. Allows column re-ordering. Optimized to not update tables if no columns are added.

This check and update is only run once per Exporter run.

Validation done:
- added unit tests
- Jacoco coverage checks
- findbugs checks

Manual tests:
- created a Synapse table with extra fields and wrong field types and sizes; verified the "deleted column" and "modified column" checks in the logs
- created a Synapse table with missing columns (including both health data columns and common columns) and columns out of order; verified that BridgeEX creates and reorders columns appropriately
- created a Synapse table with only swapped columns; verified that BridgeEX doesn't update the table if there are no new columns
