### PR TITLE
add heartbeat logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
         <aws.version>1.10.49</aws.version>
         <jackson.version>2.4.4</jackson.version>
         <java.version>1.8</java.version>
+        <logback.version>1.1.6</logback.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
     </properties>
@@ -71,7 +72,7 @@
         <dependency>
             <groupId>org.sagebionetworks</groupId>
             <artifactId>bridge-base</artifactId>
-            <version>1.2</version>
+            <version>1.5</version>
         </dependency>
         <dependency>
             <groupId>org.sagebionetworks</groupId>
@@ -85,6 +86,19 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-logging</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>${logback.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+            <version>${logback.version}</version>
+            <scope>runtime</scope>
         </dependency>
 
         <dependency>

--- a/src/main/java/org/sagebionetworks/bridge/exporter/config/SpringConfig.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/config/SpringConfig.java
@@ -25,6 +25,7 @@ import org.sagebionetworks.bridge.config.PropertiesConfig;
 import org.sagebionetworks.bridge.dynamodb.DynamoQueryHelper;
 import org.sagebionetworks.bridge.exporter.request.BridgeExporterSqsCallback;
 import org.sagebionetworks.bridge.file.FileHelper;
+import org.sagebionetworks.bridge.heartbeat.HeartbeatLogger;
 import org.sagebionetworks.bridge.s3.S3Helper;
 import org.sagebionetworks.bridge.sqs.PollSqsWorker;
 import org.sagebionetworks.bridge.sqs.SqsHelper;
@@ -110,6 +111,13 @@ public class SpringConfig {
     @Bean
     public FileHelper fileHelper() {
         return new FileHelper();
+    }
+
+    @Bean
+    public HeartbeatLogger heartbeatLogger() {
+        HeartbeatLogger heartbeatLogger = new HeartbeatLogger();
+        heartbeatLogger.setIntervalMinutes(bridgeConfig().getInt("heartbeat.interval.minutes"));
+        return heartbeatLogger;
     }
 
     @Bean

--- a/src/main/java/org/sagebionetworks/bridge/exporter/config/WorkerLauncher.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/config/WorkerLauncher.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.stereotype.Component;
 
+import org.sagebionetworks.bridge.heartbeat.HeartbeatLogger;
 import org.sagebionetworks.bridge.sqs.PollSqsWorker;
 
 /**
@@ -16,7 +17,13 @@ import org.sagebionetworks.bridge.sqs.PollSqsWorker;
 public class WorkerLauncher implements CommandLineRunner {
     private static final Logger LOG = LoggerFactory.getLogger(WorkerLauncher.class);
 
+    private HeartbeatLogger heartbeatLogger;
     private PollSqsWorker sqsWorker;
+
+    @Autowired
+    public final void setHeartbeatLogger(HeartbeatLogger heartbeatLogger) {
+        this.heartbeatLogger = heartbeatLogger;
+    }
 
     // This is singleton, because the bottleneck is how many threads we can spin up to handle one export job, not how
     // many export jobs we can do in parallel. If we for some reason find we need to do parallel export jobs, we can
@@ -34,7 +41,10 @@ public class WorkerLauncher implements CommandLineRunner {
      */
     @Override
     public void run(String... args) {
+        LOG.info("Starting heartbeat...");
+        new Thread(heartbeatLogger).start();
+
         LOG.info("Starting worker...");
-        sqsWorker.run();
+        new Thread(sqsWorker).start();
     }
 }

--- a/src/main/resources/BridgeExporter.conf
+++ b/src/main/resources/BridgeExporter.conf
@@ -6,6 +6,7 @@ synapse.api.key=your-api-key-here
 synapse.principal.id=your-principal-id-here
 
 exporter.request.sqs.sleep.time.millis=125
+heartbeat.interval.minutes=30
 record.loop.delay.millis=30
 record.loop.progress.report.period=1000
 synapse.async.interval.millis = 1000

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -11,4 +11,5 @@
     </root>
 
     <logger name="org.sagebionetworks.bridge.exporter" level="INFO" />
+    <logger name="org.sagebionetworks.bridge.heartbeat" level="INFO" />
 </configuration>


### PR DESCRIPTION
Added heartbeat logging to ensure we have logs every hour. Set heartbeat interval to 30 min as an arbitrary number smaller than 1 hour, but not too small.

Testing done:
- Ran worker locally, verified Heartbeat message in the logs

Also had to fix some dependency issues with Logback.
