### PR TITLE
support for start/endDateTime to enable hourly and on-demand exports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <properties>
         <aws.version>1.10.49</aws.version>
-        <jackson.version>2.4.4</jackson.version>
+        <jackson.version>2.7.4</jackson.version>
         <java.version>1.8</java.version>
         <logback.version>1.1.6</logback.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
@@ -72,7 +72,7 @@
         <dependency>
             <groupId>org.sagebionetworks</groupId>
             <artifactId>bridge-base</artifactId>
-            <version>1.5</version>
+            <version>2.2</version>
         </dependency>
         <dependency>
             <groupId>org.sagebionetworks</groupId>

--- a/src/main/java/org/sagebionetworks/bridge/exporter/config/SpringConfig.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/config/SpringConfig.java
@@ -93,6 +93,11 @@ public class SpringConfig {
         return ddbClient().getTable(ddbPrefix() + "HealthDataRecord3");
     }
 
+    @Bean(name = "ddbRecordStudyUploadedOnIndex")
+    public Index ddbRecordStudyUploadedOnIndex() {
+        return ddbRecordTable().getIndex("study-uploadedOn-index");
+    }
+
     @Bean(name = "ddbRecordUploadDateIndex")
     public Index ddbRecordUploadDateIndex() {
         return ddbRecordTable().getIndex("uploadDate-index");

--- a/src/main/java/org/sagebionetworks/bridge/exporter/record/BridgeExporterRecordProcessor.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/record/BridgeExporterRecordProcessor.java
@@ -110,7 +110,7 @@ public class BridgeExporterRecordProcessor {
      *         if we fail to get the record IDs from the record ID factory
      */
     public void processRecordsForRequest(BridgeExporterRequest request) throws IOException {
-        LOG.info("Received request " + request.toLogString());
+        LOG.info("Received request " + request.toString());
 
         // make task
         Metrics metrics = new Metrics();
@@ -165,7 +165,7 @@ public class BridgeExporterRecordProcessor {
             workerManager.endOfStream(task);
         } finally {
             LOG.info("Finished processing request in " + stopwatch.elapsed(TimeUnit.SECONDS) + " seconds, " +
-                    request.toLogString());
+                    request.toString());
             metricsHelper.publishMetrics(metrics);
         }
 

--- a/src/main/java/org/sagebionetworks/bridge/exporter/record/RecordIdSourceFactory.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/record/RecordIdSourceFactory.java
@@ -1,19 +1,26 @@
 package org.sagebionetworks.bridge.exporter.record;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 import javax.annotation.Resource;
 
 import com.amazonaws.services.dynamodbv2.document.Index;
 import com.amazonaws.services.dynamodbv2.document.Item;
+import com.amazonaws.services.dynamodbv2.document.RangeKeyCondition;
+import com.google.common.collect.Iterables;
 import org.apache.commons.lang.StringUtils;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.LocalDate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import org.sagebionetworks.bridge.config.Config;
 import org.sagebionetworks.bridge.dynamodb.DynamoQueryHelper;
 import org.sagebionetworks.bridge.exporter.request.BridgeExporterRequest;
+import org.sagebionetworks.bridge.exporter.util.BridgeExporterUtil;
 import org.sagebionetworks.bridge.s3.S3Helper;
 
 /**
@@ -30,33 +37,42 @@ public class RecordIdSourceFactory {
 
     // config vars
     private String overrideBucket;
+    private DateTimeZone timeZone;
 
     // Spring helpers
     private DynamoQueryHelper ddbQueryHelper;
+    private Index ddbRecordStudyUploadedOnIndex;
     private Index ddbRecordUploadDateIndex;
     private S3Helper s3Helper;
 
     /** Config, used to get S3 bucket for record ID override files. */
     @Autowired
-    public final void setConfig(Config config) {
+    final void setConfig(Config config) {
         overrideBucket = config.get(CONFIG_KEY_RECORD_ID_OVERRIDE_BUCKET);
+        timeZone = DateTimeZone.forID(config.get(BridgeExporterUtil.CONFIG_KEY_TIME_ZONE_NAME));
     }
 
     /** DDB Query Helper, used to abstract away query logic. */
     @Autowired
-    public final void setDdbQueryHelper(DynamoQueryHelper ddbQueryHelper) {
+    final void setDdbQueryHelper(DynamoQueryHelper ddbQueryHelper) {
         this.ddbQueryHelper = ddbQueryHelper;
+    }
+
+    /** DDB Record table studyId-uploadedOn index. */
+    @Resource(name = "ddbRecordStudyUploadedOnIndex")
+    final void setDdbRecordStudyUploadedOnIndex(Index ddbRecordStudyUploadedOnIndex) {
+        this.ddbRecordStudyUploadedOnIndex = ddbRecordStudyUploadedOnIndex;
     }
 
     /** DDB Record table Upload Date index. */
     @Resource(name = "ddbRecordUploadDateIndex")
-    public final void setDdbRecordUploadDateIndex(Index ddbRecordUploadDateIndex) {
+    final void setDdbRecordUploadDateIndex(Index ddbRecordUploadDateIndex) {
         this.ddbRecordUploadDateIndex = ddbRecordUploadDateIndex;
     }
 
     /** S3 Helper, used to download record ID override files. */
     @Autowired
-    public final void setS3Helper(S3Helper s3Helper) {
+    final void setS3Helper(S3Helper s3Helper) {
         this.s3Helper = s3Helper;
     }
 
@@ -73,9 +89,55 @@ public class RecordIdSourceFactory {
     public Iterable<String> getRecordSourceForRequest(BridgeExporterRequest request) throws IOException {
         if (StringUtils.isNotBlank(request.getRecordIdS3Override())) {
             return getS3RecordIdSource(request);
+        } else if (request.getStudyWhitelist() != null) {
+            return getDynamoRecordIdSourceWithStudyWhitelist(request);
         } else {
             return getDynamoRecordIdSource(request);
         }
+    }
+
+    /**
+     * If we have a study whitelist, we should always use the study-uploadedOn index, as it's more performant. If we
+     * have a date, we'll need to compute the start and endDateTimes based off of that. Otherwise, we use the start-
+     * and endDateTimes verbatim.
+     */
+    private Iterable<String> getDynamoRecordIdSourceWithStudyWhitelist(BridgeExporterRequest request) {
+        // Compute start- and endDateTime.
+        DateTime startDateTime;
+        DateTime endDateTime;
+        if (request.getDate() != null) {
+            // startDateTime is obviously date at midnight local time. endDateTime is the start of the next day.
+            LocalDate date = request.getDate();
+            startDateTime = date.toDateTimeAtStartOfDay(timeZone);
+            endDateTime = date.plusDays(1).toDateTimeAtStartOfDay(timeZone);
+        } else {
+            // Logically, if there is no date, there must be a start- and endDateTime. (We check for recordIdS3Override
+            // in the calling method.
+            startDateTime = request.getStartDateTime();
+            endDateTime = request.getEndDateTime();
+        }
+
+        // startDateTime is inclusive but endDateTime is exclusive. This is so that if a record happens to fall right
+        // on the overlap, it's only exported once. DDB doesn't allow us to do AND conditions in a range key query,
+        // and the BETWEEN is always inclusive. However, the granularity is down to the millisecond, so we can just
+        // use endDateTime minus 1 millisecond.
+        long startEpochTime = startDateTime.getMillis();
+        long endEpochTime = endDateTime.getMillis() - 1;
+
+        // RangeKeyCondition can be shared across multiple queries.
+        RangeKeyCondition rangeKeyCondition = new RangeKeyCondition("uploadedOn").between(startEpochTime,
+                endEpochTime);
+
+        // We need to make a separate query for _each_ study in the whitelist. That's just how DDB hash keys work.
+        List<Iterable<Item>> recordItemIterList = new ArrayList<>();
+        for (String oneStudyId : request.getStudyWhitelist()) {
+            Iterable<Item> recordItemIter = ddbQueryHelper.query(ddbRecordStudyUploadedOnIndex, "studyId", oneStudyId,
+                    rangeKeyCondition);
+            recordItemIterList.add(recordItemIter);
+        }
+
+        // Concatenate all the iterables together.
+        return new RecordIdSource<>(Iterables.concat(recordItemIterList), DYNAMO_ITEM_CONVERTER);
     }
 
     /** Get the record ID source from a DDB query. */

--- a/src/main/java/org/sagebionetworks/bridge/exporter/request/BridgeExporterRequest.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/request/BridgeExporterRequest.java
@@ -142,7 +142,8 @@ public class BridgeExporterRequest {
      * Converts the request to a string for use in log messages. Only contains the tag and a basic parameter to
      * identify the record source.
      */
-    public String toLogString() {
+    @Override
+    public String toString() {
         StringBuilder stringBuilder = new StringBuilder();
 
         // Record source is either date, start/endDateTime, or recordIdS3Override.

--- a/src/main/java/org/sagebionetworks/bridge/exporter/util/BridgeExporterUtil.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/util/BridgeExporterUtil.java
@@ -18,6 +18,7 @@ public class BridgeExporterUtil {
     private static final Logger LOG = LoggerFactory.getLogger(BridgeExporterUtil.class);
 
     public static final Joiner COMMA_SPACE_JOINER = Joiner.on(", ").useForNull("");
+    public static final String CONFIG_KEY_TIME_ZONE_NAME = "time.zone.name";
 
     private static final ImmutableSetMultimap<UploadSchemaKey, String> SCHEMA_FIELDS_TO_CONVERT;
     static {

--- a/src/main/java/org/sagebionetworks/bridge/exporter/worker/ExportWorkerManager.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/worker/ExportWorkerManager.java
@@ -444,7 +444,7 @@ public class ExportWorkerManager {
      */
     public void endOfStream(ExportTask task) {
         BridgeExporterRequest request = task.getRequest();
-        LOG.info("End of stream signaled for request " + request.toLogString());
+        LOG.info("End of stream signaled for request " + request.toString());
 
         // Wait for all outstanding tasks to complete
         Stopwatch stopwatch = Stopwatch.createStarted();
@@ -465,7 +465,7 @@ public class ExportWorkerManager {
             }
         }
 
-        LOG.info("All subtasks done for request " + request.toLogString());
+        LOG.info("All subtasks done for request " + request.toString());
 
         // Tell each handler to upload their TSVs to Synapse.
         for (Map.Entry<UploadSchemaKey, HealthDataExportHandler> healthDataHandlerEntry
@@ -500,6 +500,6 @@ public class ExportWorkerManager {
             }
         }
 
-        LOG.info("Done uploading to Synapse for request " + request.toLogString());
+        LOG.info("Done uploading to Synapse for request " + request.toString());
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/exporter/worker/ExportWorkerManager.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/worker/ExportWorkerManager.java
@@ -444,7 +444,7 @@ public class ExportWorkerManager {
      */
     public void endOfStream(ExportTask task) {
         BridgeExporterRequest request = task.getRequest();
-        LOG.info("End of stream signaled for request with date=" + request.getDate() + ", tag=" + request.getTag());
+        LOG.info("End of stream signaled for request " + request.toLogString());
 
         // Wait for all outstanding tasks to complete
         Stopwatch stopwatch = Stopwatch.createStarted();
@@ -465,7 +465,7 @@ public class ExportWorkerManager {
             }
         }
 
-        LOG.info("All subtasks done for request with date=" + request.getDate() + ", tag=" + request.getTag());
+        LOG.info("All subtasks done for request " + request.toLogString());
 
         // Tell each handler to upload their TSVs to Synapse.
         for (Map.Entry<UploadSchemaKey, HealthDataExportHandler> healthDataHandlerEntry
@@ -500,6 +500,6 @@ public class ExportWorkerManager {
             }
         }
 
-        LOG.info("Done uploading to Synapse for request with date=" + request.getDate() + ", tag=" + request.getTag());
+        LOG.info("Done uploading to Synapse for request " + request.toLogString());
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/exporter/record/BridgeExporterRecordProcessorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/record/BridgeExporterRecordProcessorTest.java
@@ -25,6 +25,7 @@ import org.sagebionetworks.bridge.config.Config;
 import org.sagebionetworks.bridge.exporter.metrics.Metrics;
 import org.sagebionetworks.bridge.exporter.metrics.MetricsHelper;
 import org.sagebionetworks.bridge.exporter.request.BridgeExporterRequest;
+import org.sagebionetworks.bridge.exporter.util.BridgeExporterUtil;
 import org.sagebionetworks.bridge.exporter.worker.ExportTask;
 import org.sagebionetworks.bridge.exporter.worker.ExportWorkerManager;
 import org.sagebionetworks.bridge.file.InMemoryFileHelper;
@@ -48,7 +49,7 @@ public class BridgeExporterRecordProcessorTest {
         when(mockConfig.getInt(BridgeExporterRecordProcessor.CONFIG_KEY_RECORD_LOOP_DELAY_MILLIS)).thenReturn(0);
         when(mockConfig.getInt(BridgeExporterRecordProcessor.CONFIG_KEY_RECORD_LOOP_PROGRESS_REPORT_PERIOD))
                 .thenReturn(2);
-        when(mockConfig.get(BridgeExporterRecordProcessor.CONFIG_KEY_TIME_ZONE_NAME))
+        when(mockConfig.get(BridgeExporterUtil.CONFIG_KEY_TIME_ZONE_NAME))
                 .thenReturn("America/Los_Angeles");
 
         // mock DDB record table - We don't look inside any of these records, so for the purposes of this test, just

--- a/src/test/java/org/sagebionetworks/bridge/exporter/record/RecordIdSourceFactoryTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/record/RecordIdSourceFactoryTest.java
@@ -1,20 +1,29 @@
 package org.sagebionetworks.bridge.exporter.record;
 
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.same;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 
 import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
 
 import com.amazonaws.services.dynamodbv2.document.Index;
 import com.amazonaws.services.dynamodbv2.document.Item;
+import com.amazonaws.services.dynamodbv2.document.KeyConditions;
+import com.amazonaws.services.dynamodbv2.document.RangeKeyCondition;
 import com.google.common.collect.ImmutableList;
+import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
+import org.mockito.ArgumentCaptor;
 import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.config.Config;
 import org.sagebionetworks.bridge.dynamodb.DynamoQueryHelper;
 import org.sagebionetworks.bridge.exporter.request.BridgeExporterRequest;
+import org.sagebionetworks.bridge.exporter.util.BridgeExporterUtil;
 import org.sagebionetworks.bridge.s3.S3Helper;
 
 public class RecordIdSourceFactoryTest {
@@ -46,12 +55,83 @@ public class RecordIdSourceFactoryTest {
     }
 
     @Test
-    public void fromS3Override() throws Exception {
-        // mock config
-        Config mockConfig = mock(Config.class);
-        when(mockConfig.get(RecordIdSourceFactory.CONFIG_KEY_RECORD_ID_OVERRIDE_BUCKET))
-                .thenReturn("dummy-override-bucket");
+    public void fromDdbWithWhitelistAndDate() throws Exception {
+        BridgeExporterRequest.Builder requestBuilder = new BridgeExporterRequest.Builder().withDate(LocalDate.parse(
+                "2016-05-09"));
+        fromDdbWithWhitelist(requestBuilder, DateTime.parse("2016-05-09T00:00:00.000-0700").getMillis(),
+                DateTime.parse("2016-05-09T23:59:59.999-0700").getMillis());
+    }
 
+    @Test
+    public void fromDdbWithWhitelistAndStartAndEndDateTime() throws Exception {
+        DateTime startDateTime = DateTime.parse("2016-05-09T02:36:19.643-0700");
+        DateTime endDateTime = DateTime.parse("2016-05-09T17:46:32.901-0700");
+
+        BridgeExporterRequest.Builder requestBuilder = new BridgeExporterRequest.Builder()
+                .withStartDateTime(startDateTime).withEndDateTime(endDateTime);
+
+        fromDdbWithWhitelist(requestBuilder, startDateTime.getMillis(), endDateTime.getMillis() - 1);
+    }
+
+    private static void fromDdbWithWhitelist(BridgeExporterRequest.Builder requestBuilder, long expectedStartMillis,
+            long expectedEndMillis) throws Exception {
+        // mock DDB
+        List<Item> barStudyItemList = ImmutableList.of(new Item().withString("id", "bar-1"),
+                new Item().withString("id", "bar-2"));
+        List<Item> fooStudyItemList = ImmutableList.of(new Item().withString("id", "foo-1"),
+                new Item().withString("id", "foo-2"));
+
+        Index mockRecordIndex = mock(Index.class);
+        DynamoQueryHelper mockQueryHelper = mock(DynamoQueryHelper.class);
+
+        ArgumentCaptor<RangeKeyCondition> barRangeKeyCaptor = ArgumentCaptor.forClass(RangeKeyCondition.class);
+        when(mockQueryHelper.query(same(mockRecordIndex), eq("studyId"), eq("bar-study"), barRangeKeyCaptor.capture()))
+                .thenReturn(barStudyItemList);
+
+        ArgumentCaptor<RangeKeyCondition> fooRangeKeyCaptor = ArgumentCaptor.forClass(RangeKeyCondition.class);
+        when(mockQueryHelper.query(same(mockRecordIndex), eq("studyId"), eq("foo-study"), fooRangeKeyCaptor.capture()))
+                .thenReturn(fooStudyItemList);
+
+        // set up factory
+        RecordIdSourceFactory factory = new RecordIdSourceFactory();
+        factory.setConfig(mockConfig());
+        factory.setDdbQueryHelper(mockQueryHelper);
+        factory.setDdbRecordStudyUploadedOnIndex(mockRecordIndex);
+
+        // finish building request - Use a TreeSet for the study whitelist, so we can get a deterministic test.
+        // (ImmutableSet preserves the iteration order.)
+        Set<String> studyWhitelist = new TreeSet<>();
+        studyWhitelist.add("bar-study");
+        studyWhitelist.add("foo-study");
+        BridgeExporterRequest request = requestBuilder.withStudyWhitelist(studyWhitelist).build();
+
+        // execute and validate
+        Iterable<String> recordIdIter = factory.getRecordSourceForRequest(request);
+        List<String> recordIdList = ImmutableList.copyOf(recordIdIter);
+        assertEquals(recordIdList.size(), 4);
+        assertEquals(recordIdList.get(0), "bar-1");
+        assertEquals(recordIdList.get(1), "bar-2");
+        assertEquals(recordIdList.get(2), "foo-1");
+        assertEquals(recordIdList.get(3), "foo-2");
+
+        // validate range key queries
+        validateRangeKey(barRangeKeyCaptor.getValue(), expectedStartMillis, expectedEndMillis);
+        validateRangeKey(fooRangeKeyCaptor.getValue(), expectedStartMillis, expectedEndMillis);
+    }
+
+    private static void validateRangeKey(RangeKeyCondition rangeKey, long expectedStartMillis,
+            long expectedEndMillis) {
+        assertEquals(rangeKey.getAttrName(), "uploadedOn");
+        assertEquals(rangeKey.getKeyCondition(), KeyConditions.BETWEEN);
+
+        Object[] rangeKeyValueArray = rangeKey.getValues();
+        assertEquals(rangeKeyValueArray.length, 2);
+        assertEquals(rangeKeyValueArray[0], expectedStartMillis);
+        assertEquals(rangeKeyValueArray[1], expectedEndMillis);
+    }
+
+    @Test
+    public void fromS3Override() throws Exception {
         // mock S3
         List<String> s3Lines = ImmutableList.of("s3-foo", "s3-bar", "s3-baz");
         S3Helper mockS3Helper = mock(S3Helper.class);
@@ -59,7 +139,7 @@ public class RecordIdSourceFactoryTest {
 
         // set up factory
         RecordIdSourceFactory factory = new RecordIdSourceFactory();
-        factory.setConfig(mockConfig);
+        factory.setConfig(mockConfig());
         factory.setS3Helper(mockS3Helper);
 
         // execute and validate
@@ -72,5 +152,13 @@ public class RecordIdSourceFactoryTest {
         assertEquals(recordIdList.get(0), "s3-foo");
         assertEquals(recordIdList.get(1), "s3-bar");
         assertEquals(recordIdList.get(2), "s3-baz");
+    }
+
+    private static Config mockConfig() {
+        Config mockConfig = mock(Config.class);
+        when(mockConfig.get(RecordIdSourceFactory.CONFIG_KEY_RECORD_ID_OVERRIDE_BUCKET))
+                .thenReturn("dummy-override-bucket");
+        when(mockConfig.get(BridgeExporterUtil.CONFIG_KEY_TIME_ZONE_NAME)).thenReturn("America/Los_Angeles");
+        return mockConfig;
     }
 }


### PR DESCRIPTION
There are now two indices on the records table, one on uploadDate and one on studyId+uploadedOn. This enables us to use a range query on uploadedOn, which enable hourly exports and on-demand exports.

The one limitation is uploadedOn must be a range key, so we use the study ID as the hash key. This is fine, because uploadedOn will only be used on specific studies.

This also has the side effect of optimizing our studyWhitelist usage. Before, we'd get every record for a day and filter out the ones that don't match the study. Now, we can use the studyId-uploadedOn-index to only query for the records in our study.

Testing done:
- added unit tests
- manual tests (a) studyWhitelist w/ start/endDateTimes (b) studyWhitelist w/ date (c) all studies w/ date (normal use case)

Next steps:
- A mechanism so studies don't get exported by both the hourly schedule and the "default" schedule
- Configure a separate scheduler for hourly exports
