### PR TITLE
usesCustomExportSchedule flag

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/exporter/dynamo/DynamoHelper.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/dynamo/DynamoHelper.java
@@ -30,6 +30,7 @@ public class DynamoHelper {
 
     private static final String STUDY_INFO_KEY_DATA_ACCESS_TEAM = "synapseDataAccessTeamId";
     private static final String STUDY_INFO_KEY_PROJECT_ID = "synapseProjectId";
+    private static final String STUDY_INFO_KEY_USES_CUSTOM_EXPORT_SCHEDULE = "usesCustomExportSchedule";
 
     private Table ddbParticipantOptionsTable;
     private Table ddbSchemaTable;
@@ -138,9 +139,17 @@ public class DynamoHelper {
         if (studyItem.get(STUDY_INFO_KEY_DATA_ACCESS_TEAM) != null) {
             studyInfoBuilder.withDataAccessTeamId(studyItem.getLong(STUDY_INFO_KEY_DATA_ACCESS_TEAM));
         }
+
         if (studyItem.get(STUDY_INFO_KEY_PROJECT_ID) != null) {
             studyInfoBuilder.withSynapseProjectId(studyItem.getString(STUDY_INFO_KEY_PROJECT_ID));
         }
+
+        if (studyItem.get(STUDY_INFO_KEY_USES_CUSTOM_EXPORT_SCHEDULE) != null) {
+            // For some reason, the mapper saves the value as an int, not as a boolean.
+            boolean usesCustomExportSchedule = studyItem.getInt(STUDY_INFO_KEY_USES_CUSTOM_EXPORT_SCHEDULE) != 0;
+            studyInfoBuilder.withUsesCustomExportSchedule(usesCustomExportSchedule);
+        }
+
         return studyInfoBuilder.build();
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/exporter/dynamo/StudyInfo.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/dynamo/StudyInfo.java
@@ -29,8 +29,8 @@ public class StudyInfo {
     }
 
     /**
-     * True if BridgeEX should include it in the "default" nightly job (which is an export job without a study
-     * whitelist). False otherwise.
+     * False if BridgeEX should include it in the "default" nightly job (which is an export job without a study
+     * whitelist). True otherwise.
      */
     public boolean getUsesCustomExportSchedule() {
         return usesCustomExportSchedule;

--- a/src/main/java/org/sagebionetworks/bridge/exporter/dynamo/StudyInfo.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/dynamo/StudyInfo.java
@@ -9,11 +9,13 @@ import org.apache.commons.lang.StringUtils;
 public class StudyInfo {
     private final Long dataAccessTeamId;
     private final String synapseProjectId;
+    private final boolean usesCustomExportSchedule;
 
     /** Private constructor. To construct, see builder. */
-    private StudyInfo(Long dataAccessTeamId, String synapseProjectId) {
+    private StudyInfo(Long dataAccessTeamId, String synapseProjectId, boolean usesCustomExportSchedule) {
         this.dataAccessTeamId = dataAccessTeamId;
         this.synapseProjectId = synapseProjectId;
+        this.usesCustomExportSchedule = usesCustomExportSchedule;
     }
 
     /** The team ID of the team that is granted read access to exported data. */
@@ -26,10 +28,19 @@ public class StudyInfo {
         return synapseProjectId;
     }
 
+    /**
+     * True if BridgeEX should include it in the "default" nightly job (which is an export job without a study
+     * whitelist). False otherwise.
+     */
+    public boolean getUsesCustomExportSchedule() {
+        return usesCustomExportSchedule;
+    }
+
     /** StudyInfo Builder. */
     public static class Builder {
         private Long dataAccessTeamId;
         private String synapseProjectId;
+        private Boolean usesCustomExportSchedule;
 
         /** @see StudyInfo#getDataAccessTeamId */
         public Builder withDataAccessTeamId(Long dataAccessTeamId) {
@@ -43,6 +54,12 @@ public class StudyInfo {
             return this;
         }
 
+        /** @see StudyInfo#getUsesCustomExportSchedule */
+        public Builder withUsesCustomExportSchedule(Boolean usesCustomExportSchedule) {
+            this.usesCustomExportSchedule = usesCustomExportSchedule;
+            return this;
+        }
+
         /**
          * Builds the study info object. The study may not have been configured for Bridge-EX yet (that is, no
          * dataAccessTeamId and no synapseProjectId). If that's the case, return null instead of returning an
@@ -51,9 +68,13 @@ public class StudyInfo {
         public StudyInfo build() {
             if (dataAccessTeamId == null || StringUtils.isBlank(synapseProjectId)) {
                 return null;
-            } else {
-                return new StudyInfo(dataAccessTeamId, synapseProjectId);
             }
+
+            // usesCustomExportSchedule defaults to false.
+            boolean finalUsesCustomExportSchedule = usesCustomExportSchedule != null ? usesCustomExportSchedule :
+                    false;
+
+            return new StudyInfo(dataAccessTeamId, synapseProjectId, finalUsesCustomExportSchedule);
         }
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/exporter/dynamo/DynamoHelperTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/dynamo/DynamoHelperTest.java
@@ -3,7 +3,9 @@ package org.sagebionetworks.bridge.exporter.dynamo;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.services.dynamodbv2.document.Item;
@@ -161,6 +163,7 @@ public class DynamoHelperTest {
         StudyInfo studyInfo = helper.getStudyInfo("test-study");
         assertEquals(studyInfo.getDataAccessTeamId().longValue(), 1337);
         assertEquals(studyInfo.getSynapseProjectId(), "test-synapse-table");
+        assertFalse(studyInfo.getUsesCustomExportSchedule());
     }
 
     @Test
@@ -196,5 +199,41 @@ public class DynamoHelperTest {
         // execute and validate - Similarly, studyInfo is also null here
         StudyInfo studyInfo = helper.getStudyInfo("test-study");
         assertNull(studyInfo);
+    }
+
+    @Test
+    public void getStudyInfoCustomExportFalse() {
+        // mock DDB Study table - only include relevant attributes
+        Item studyItem = new Item().withLong("synapseDataAccessTeamId", 1337)
+                .withString("synapseProjectId", "test-synapse-table").withInt("usesCustomExportSchedule", 0);
+
+        Table mockStudyTable = mock(Table.class);
+        when(mockStudyTable.getItem("identifier", "test-study")).thenReturn(studyItem);
+
+        // set up Dynamo Helper
+        DynamoHelper helper = new DynamoHelper();
+        helper.setDdbStudyTable(mockStudyTable);
+
+        // execute and validate
+        StudyInfo studyInfo = helper.getStudyInfo("test-study");
+        assertFalse(studyInfo.getUsesCustomExportSchedule());
+    }
+
+    @Test
+    public void getStudyInfoCustomExportTrue() {
+        // mock DDB Study table - only include relevant attributes
+        Item studyItem = new Item().withLong("synapseDataAccessTeamId", 1337)
+                .withString("synapseProjectId", "test-synapse-table").withInt("usesCustomExportSchedule", 1);
+
+        Table mockStudyTable = mock(Table.class);
+        when(mockStudyTable.getItem("identifier", "test-study")).thenReturn(studyItem);
+
+        // set up Dynamo Helper
+        DynamoHelper helper = new DynamoHelper();
+        helper.setDdbStudyTable(mockStudyTable);
+
+        // execute and validate
+        StudyInfo studyInfo = helper.getStudyInfo("test-study");
+        assertTrue(studyInfo.getUsesCustomExportSchedule());
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/exporter/dynamo/StudyInfoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/dynamo/StudyInfoTest.java
@@ -1,7 +1,9 @@
 package org.sagebionetworks.bridge.exporter.dynamo;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 import org.testng.annotations.Test;
 
@@ -36,5 +38,20 @@ public class StudyInfoTest {
                 .withSynapseProjectId("test-synapse-project").build();
         assertEquals(studyInfo.getDataAccessTeamId().longValue(), 23);
         assertEquals(studyInfo.getSynapseProjectId(), "test-synapse-project");
+        assertFalse(studyInfo.getUsesCustomExportSchedule());
+    }
+
+    @Test
+    public void customExportFalse() {
+        StudyInfo studyInfo = new StudyInfo.Builder().withDataAccessTeamId(23L)
+                .withSynapseProjectId("test-synapse-project").withUsesCustomExportSchedule(false).build();
+        assertFalse(studyInfo.getUsesCustomExportSchedule());
+    }
+
+    @Test
+    public void customExportTrue() {
+        StudyInfo studyInfo = new StudyInfo.Builder().withDataAccessTeamId(23L)
+                .withSynapseProjectId("test-synapse-project").withUsesCustomExportSchedule(true).build();
+        assertTrue(studyInfo.getUsesCustomExportSchedule());
     }
 }


### PR DESCRIPTION
Update BridgeEX to parse the usesCustomExportSchedule flag and honor it.

We currently determine what is and isn't a custom export schedule based on the presence or absence of the study whitelist flag, which is needed to use the granular uploadedOn index for hourly exports. In the future, this may become more sophisticated, and we may need to shift to passing in an explicit customSchedule in the request object, but for now, I think this is a viable solution.

Testing done:
- mvn verify (findbugs, unit tests, test coverage)
- manual tests: (a) custom schedule false (b) custom schedule true w/o study whiteliest (c) custom schedule true w/ study whitelist

Next steps:
- set up hourly scheduler
