### PR TITLE
refactor to call Bridge Server for schemas

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,11 @@
             <version>2.2</version>
         </dependency>
         <dependency>
+            <groupId>org.sagebionetworks.bridge</groupId>
+            <artifactId>java-sdk</artifactId>
+            <version>0.8.2</version>
+        </dependency>
+        <dependency>
             <groupId>org.sagebionetworks</groupId>
             <artifactId>synapseJavaClient</artifactId>
             <version>131.0</version>

--- a/src/main/java/org/sagebionetworks/bridge/exporter/handler/IosSurveyExportHandler.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/handler/IosSurveyExportHandler.java
@@ -14,8 +14,8 @@ import org.sagebionetworks.bridge.exporter.metrics.Metrics;
 import org.sagebionetworks.bridge.exporter.worker.ExportSubtask;
 import org.sagebionetworks.bridge.exporter.worker.ExportTask;
 import org.sagebionetworks.bridge.exporter.worker.ExportWorkerManager;
-import org.sagebionetworks.bridge.schema.UploadSchema;
 import org.sagebionetworks.bridge.schema.UploadSchemaKey;
+import org.sagebionetworks.bridge.sdk.models.upload.UploadSchema;
 
 /**
  * This class is responsible for converting the raw survey answers into a form the Synapse Export Worker can consume.
@@ -69,7 +69,7 @@ public class IosSurveyExportHandler extends ExportHandler {
                 .withSchemaId(schemaId).withRevision(schemaRev).build();
 
         // get schema and field type map, so we can process attachments
-        UploadSchema surveySchema = manager.getDynamoHelper().getSchema(parentTask.getMetrics(), surveySchemaKey);
+        UploadSchema surveySchema = manager.getBridgeHelper().getSchema(parentTask.getMetrics(), surveySchemaKey);
 
         // convert to health data node
         JsonNode convertedSurveyNode = manager.getExportHelper().convertSurveyRecordToHealthDataJsonNode(recordId,

--- a/src/main/java/org/sagebionetworks/bridge/exporter/helper/BridgeHelper.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/helper/BridgeHelper.java
@@ -1,0 +1,58 @@
+package org.sagebionetworks.bridge.exporter.helper;
+
+import java.util.concurrent.TimeUnit;
+
+import com.jcabi.aspects.Cacheable;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import org.sagebionetworks.bridge.exporter.exceptions.SchemaNotFoundException;
+import org.sagebionetworks.bridge.exporter.metrics.Metrics;
+import org.sagebionetworks.bridge.schema.UploadSchemaKey;
+import org.sagebionetworks.bridge.sdk.ClientInfo;
+import org.sagebionetworks.bridge.sdk.WorkerClient;
+import org.sagebionetworks.bridge.sdk.models.upload.UploadSchema;
+
+/**
+ * Helper to call Bridge Server to get information such as schemas. Also wraps some of the calls to provide caching.
+ */
+@Component
+public class BridgeHelper {
+    /** BridgeEX client info to send to Bridge Server. */
+    public static final ClientInfo CLIENT_INFO = new ClientInfo.Builder().withAppName("BridgeEX").withAppVersion(2)
+            .build();
+
+    private WorkerClient workerClient;
+
+    /** Bridge Client for worker APIs. */
+    @Autowired
+    final void setWorkerClient(WorkerClient workerClient) {
+        this.workerClient = workerClient;
+    }
+
+    /**
+     * Returns the schema for the given key.
+     *
+     * @param metrics
+     *         metrics object, used to keep a record of "schemas not found"
+     * @param schemaKey
+     *         key for the schema to get
+     * @return the schema
+     * @throws SchemaNotFoundException
+     *         if the schema doesn't exist
+     */
+    public UploadSchema getSchema(Metrics metrics, UploadSchemaKey schemaKey) throws SchemaNotFoundException {
+        UploadSchema schema = getSchemaCached(schemaKey);
+        if (schema == null) {
+            metrics.addKeyValuePair("schemasNotFound", schemaKey.toString());
+            throw new SchemaNotFoundException("Schema not found: " + schemaKey.toString());
+        }
+        return schema;
+    }
+
+    // Helper method that encapsulates just the service call, cached with annotation.
+    @Cacheable(lifetime = 5, unit = TimeUnit.MINUTES)
+    private UploadSchema getSchemaCached(UploadSchemaKey schemaKey) {
+        return workerClient.getSchema(schemaKey.getStudyId(), schemaKey.getSchemaId(), schemaKey.getRevision());
+    }
+}

--- a/src/main/java/org/sagebionetworks/bridge/exporter/util/BridgeExporterUtil.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/util/BridgeExporterUtil.java
@@ -1,5 +1,7 @@
 package org.sagebionetworks.bridge.exporter.util;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import com.amazonaws.services.dynamodbv2.document.Item;
@@ -12,6 +14,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.sagebionetworks.bridge.schema.UploadSchemaKey;
+import org.sagebionetworks.bridge.sdk.models.upload.UploadFieldDefinition;
+import org.sagebionetworks.bridge.sdk.models.upload.UploadSchema;
 
 /** Various static utility methods that don't neatly fit anywhere else. */
 public class BridgeExporterUtil {
@@ -39,6 +43,21 @@ public class BridgeExporterUtil {
     }
 
     /**
+     * Helper method to get a field definition map from a schema, keyed by field name
+     *
+     * @param schema
+     *         schema to get field definition map from
+     * @return field definition map
+     */
+    public static Map<String, UploadFieldDefinition> getFieldDefMapFromSchema(UploadSchema schema) {
+        Map<String, UploadFieldDefinition> fieldDefMap = new HashMap<>();
+        for (UploadFieldDefinition oneFieldDef : schema.getFieldDefinitions()) {
+            fieldDefMap.put(oneFieldDef.getName(), oneFieldDef);
+        }
+        return fieldDefMap;
+    }
+
+    /**
      * Helper method to get the schema key for a DDB health data record
      *
      * @param record
@@ -51,6 +70,18 @@ public class BridgeExporterUtil {
         int schemaRev = record.getInt("schemaRevision");
         return new UploadSchemaKey.Builder().withStudyId(studyId).withSchemaId(schemaId).withRevision(schemaRev)
                 .build();
+    }
+
+    /**
+     * Helper method to get an UploadSchemaKey object from a schema.
+     *
+     * @param schema
+     *         schema to get key from
+     * @return schema key
+     */
+    public static UploadSchemaKey getSchemaKeyFromSchema(UploadSchema schema) {
+        return new UploadSchemaKey.Builder().withStudyId(schema.getStudyId()).withSchemaId(schema.getSchemaId())
+                .withRevision(schema.getRevision()).build();
     }
 
     /**

--- a/src/main/resources/BridgeExporter.conf
+++ b/src/main/resources/BridgeExporter.conf
@@ -1,6 +1,10 @@
 bridge.env=local
 bridge.user=your-username-here
 
+bridge.worker.study=your-worker-account-here
+bridge.worker.email=your-worker-account-here
+bridge.worker.password=your-worker-account-here
+
 synapse.user=your-username-here
 synapse.api.key=your-api-key-here
 synapse.principal.id=your-principal-id-here

--- a/src/test/java/org/sagebionetworks/bridge/exporter/dynamo/DynamoHelperTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/dynamo/DynamoHelperTest.java
@@ -12,56 +12,8 @@ import com.amazonaws.services.dynamodbv2.document.Item;
 import com.amazonaws.services.dynamodbv2.document.Table;
 import org.testng.annotations.Test;
 
-import org.sagebionetworks.bridge.exporter.exceptions.SchemaNotFoundException;
-import org.sagebionetworks.bridge.exporter.metrics.Metrics;
-import org.sagebionetworks.bridge.schema.UploadSchema;
-import org.sagebionetworks.bridge.schema.UploadSchemaKey;
-
 @SuppressWarnings("unchecked")
 public class DynamoHelperTest {
-    @Test
-    public void getSchema() throws Exception {
-        // mock DDB Schema table
-        String fieldDefListJson = "[\n" +
-                "   {\n" +
-                "       \"name\":\"foo-field\",\n" +
-                "       \"type\":\"STRING\"\n" +
-                "   }\n" +
-                "]";
-        Item dummySchemaItem = new Item().withString("key", "test-study:test-schema").withInt("revision", 42)
-                .withString("fieldDefinitions", fieldDefListJson);
-
-        Table mockSchemaTable = mock(Table.class);
-        when(mockSchemaTable.getItem("key", "test-study:test-schema", "revision", 42)).thenReturn(dummySchemaItem);
-
-        // set up Dynamo Helper
-        DynamoHelper helper = new DynamoHelper();
-        helper.setDdbSchemaTable(mockSchemaTable);
-
-        // execute and validate - The goal here isn't an exhaustive test of parsing an DDB record into an Upload
-        // Schema. That's handled by bridge-base. Just verify basic params.
-        UploadSchemaKey schemaKey = new UploadSchemaKey.Builder().withStudyId("test-study").withSchemaId("test-schema")
-                .withRevision(42).build();
-        UploadSchema schema = helper.getSchema(new Metrics(), schemaKey);
-        assertEquals(schema.getKey().toString(), "test-study-test-schema-v42");
-    }
-
-    @Test(expectedExceptions = SchemaNotFoundException.class)
-    public void schemaNotFound() throws Exception {
-        // mock DDB Schema table
-        Table mockSchemaTable = mock(Table.class);
-        when(mockSchemaTable.getItem("key", "test-study:missing-schema", "revision", 3)).thenReturn(null);
-
-        // set up Dynamo Helper
-        DynamoHelper helper = new DynamoHelper();
-        helper.setDdbSchemaTable(mockSchemaTable);
-
-        // execute and validate
-        UploadSchemaKey schemaKey = new UploadSchemaKey.Builder().withStudyId("test-study")
-                .withSchemaId("missing-schema").withRevision(3).build();
-        helper.getSchema(new Metrics(), schemaKey);
-    }
-
     @Test
     public void getSharingScope() {
         // mock DDB Participant Options table

--- a/src/test/java/org/sagebionetworks/bridge/exporter/handler/IosSurveyExportHandlerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/handler/IosSurveyExportHandlerTest.java
@@ -21,7 +21,8 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import org.sagebionetworks.bridge.exporter.dynamo.DynamoHelper;
+import org.sagebionetworks.bridge.exporter.helper.BridgeHelper;
+import org.sagebionetworks.bridge.exporter.helper.BridgeHelperTest;
 import org.sagebionetworks.bridge.exporter.helper.ExportHelper;
 import org.sagebionetworks.bridge.exporter.metrics.Metrics;
 import org.sagebionetworks.bridge.exporter.request.BridgeExporterRequest;
@@ -29,7 +30,6 @@ import org.sagebionetworks.bridge.exporter.worker.ExportSubtask;
 import org.sagebionetworks.bridge.exporter.worker.ExportTask;
 import org.sagebionetworks.bridge.exporter.worker.ExportWorkerManager;
 import org.sagebionetworks.bridge.json.DefaultObjectMapper;
-import org.sagebionetworks.bridge.schema.UploadSchema;
 import org.sagebionetworks.bridge.schema.UploadSchemaKey;
 
 // Test strategy here is a one question survey. Survey conversion is tested in the ExportHelper, so we just only test
@@ -56,7 +56,7 @@ public class IosSurveyExportHandlerTest {
     public void setup() throws Exception {
         // set up manager
         ExportWorkerManager manager = spy(new ExportWorkerManager());
-        manager.setDynamoHelper(mock(DynamoHelper.class));
+        manager.setBridgeHelper(mock(BridgeHelper.class));
         manager.setExportHelper(mock(ExportHelper.class));
 
         // set up handler
@@ -99,7 +99,7 @@ public class IosSurveyExportHandlerTest {
 
         // verify that the manager's mock helpers were not called
         ExportWorkerManager manager = handler.getManager();
-        verifyZeroInteractions(manager.getDynamoHelper(), manager.getExportHelper());
+        verifyZeroInteractions(manager.getBridgeHelper(), manager.getExportHelper());
 
         // verify metrics
         Multiset<String> counterMap = subtask.getParentTask().getMetrics().getCounterMap();
@@ -124,14 +124,13 @@ public class IosSurveyExportHandlerTest {
         // get manager
         ExportWorkerManager manager = handler.getManager();
 
-        // mock Dynamo Helper
-        UploadSchema schema = new UploadSchema.Builder().withKey(SCHEMA_KEY_REAL).addField("foo", "STRING").build();
-        when(manager.getDynamoHelper().getSchema(metrics, SCHEMA_KEY_REAL)).thenReturn(schema);
+        // mock Bridge Helper
+        when(manager.getBridgeHelper().getSchema(metrics, SCHEMA_KEY_REAL)).thenReturn(BridgeHelperTest.TEST_SCHEMA);
 
         // mock Export Helper
         JsonNode convertedSurveyNode = DefaultObjectMapper.INSTANCE.createObjectNode();
         when(manager.getExportHelper().convertSurveyRecordToHealthDataJsonNode(DUMMY_RECORD_ID, recordDataJsonNode,
-                schema)).thenReturn(convertedSurveyNode);
+                BridgeHelperTest.TEST_SCHEMA)).thenReturn(convertedSurveyNode);
 
         // spy manager.addHealthDataSubtask()
         ArgumentCaptor<ExportSubtask> convertedSubtaskCaptor = ArgumentCaptor.forClass(ExportSubtask.class);

--- a/src/test/java/org/sagebionetworks/bridge/exporter/handler/SynapseExportHandlerNewTableTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/handler/SynapseExportHandlerNewTableTest.java
@@ -22,6 +22,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.config.Config;
+import org.sagebionetworks.bridge.exporter.helper.BridgeHelperTest;
 import org.sagebionetworks.bridge.exporter.metrics.Metrics;
 import org.sagebionetworks.bridge.exporter.synapse.SynapseHelper;
 import org.sagebionetworks.bridge.exporter.util.TestUtil;
@@ -29,7 +30,9 @@ import org.sagebionetworks.bridge.exporter.worker.ExportSubtask;
 import org.sagebionetworks.bridge.exporter.worker.ExportTask;
 import org.sagebionetworks.bridge.exporter.worker.ExportWorkerManager;
 import org.sagebionetworks.bridge.file.InMemoryFileHelper;
-import org.sagebionetworks.bridge.schema.UploadSchema;
+import org.sagebionetworks.bridge.sdk.models.upload.UploadFieldDefinition;
+import org.sagebionetworks.bridge.sdk.models.upload.UploadFieldType;
+import org.sagebionetworks.bridge.sdk.models.upload.UploadSchema;
 
 public class SynapseExportHandlerNewTableTest {
     private String ddbSynapseTableId;
@@ -168,8 +171,10 @@ public class SynapseExportHandlerNewTableTest {
     public void healthDataExportHandlerTest() throws Exception {
         // Freeform text to attachments is already tested in SynapseExportHandlerTest. Just test simple string and int
         // fields.
-        UploadSchema testSchema = new UploadSchema.Builder().withKey(SynapseExportHandlerTest.DUMMY_SCHEMA_KEY)
-                .addField("foo", "STRING").addField("bar", "INT").build();
+        UploadSchema testSchema = BridgeHelperTest.simpleSchemaBuilder().withFieldDefinitions(
+                new UploadFieldDefinition.Builder().withName("foo").withType(UploadFieldType.STRING).build(),
+                new UploadFieldDefinition.Builder().withName("bar").withType(UploadFieldType.INT).build())
+                .build();
 
         // Set up handler and test. setSchema() needs to be called before setup, since a lot of the stuff in the
         // handler depends on it, even while we're mocking stuff.

--- a/src/test/java/org/sagebionetworks/bridge/exporter/helper/BridgeHelperTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/helper/BridgeHelperTest.java
@@ -1,0 +1,77 @@
+package org.sagebionetworks.bridge.exporter.helper;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+import java.util.SortedSet;
+
+import com.google.common.collect.SortedSetMultimap;
+import org.testng.annotations.Test;
+
+import org.sagebionetworks.bridge.exporter.exceptions.SchemaNotFoundException;
+import org.sagebionetworks.bridge.exporter.metrics.Metrics;
+import org.sagebionetworks.bridge.schema.UploadSchemaKey;
+import org.sagebionetworks.bridge.sdk.WorkerClient;
+import org.sagebionetworks.bridge.sdk.models.upload.UploadFieldDefinition;
+import org.sagebionetworks.bridge.sdk.models.upload.UploadFieldType;
+import org.sagebionetworks.bridge.sdk.models.upload.UploadSchema;
+import org.sagebionetworks.bridge.sdk.models.upload.UploadSchemaType;
+
+public class BridgeHelperTest {
+    public static final UploadFieldDefinition TEST_FIELD_DEF = new UploadFieldDefinition.Builder().withName("my-field")
+            .withType(UploadFieldType.STRING).build();
+    public static final String TEST_SCHEMA_ID = "my-schema";
+    public static final int TEST_SCHEMA_REV = 2;
+    public static final String TEST_STUDY_ID = "test-study";
+
+    public static final UploadSchema TEST_SCHEMA = simpleSchemaBuilder().withFieldDefinitions(TEST_FIELD_DEF).build();
+    public static final UploadSchemaKey TEST_SCHEMA_KEY = new UploadSchemaKey.Builder().withStudyId(TEST_STUDY_ID)
+            .withSchemaId(TEST_SCHEMA_ID).withRevision(TEST_SCHEMA_REV).build();
+
+    public static UploadSchema.Builder simpleSchemaBuilder() {
+        return new UploadSchema.Builder().withName("My Schema").withRevision(TEST_SCHEMA_REV)
+                .withSchemaId(TEST_SCHEMA_ID).withSchemaType(UploadSchemaType.IOS_DATA).withStudyId(TEST_STUDY_ID);
+    }
+
+    @Test
+    public void getSchema() throws Exception {
+        // mock worker client
+        WorkerClient mockWorkerClient = mock(WorkerClient.class);
+        when(mockWorkerClient.getSchema(TEST_STUDY_ID, TEST_SCHEMA_ID, TEST_SCHEMA_REV)).thenReturn(TEST_SCHEMA);
+
+        BridgeHelper bridgeHelper = new BridgeHelper();
+        bridgeHelper.setWorkerClient(mockWorkerClient);
+
+        // execute and validate
+        UploadSchema retVal = bridgeHelper.getSchema(new Metrics(), TEST_SCHEMA_KEY);
+        assertEquals(retVal, TEST_SCHEMA);
+    }
+
+    @Test
+    public void getSchemaNotFound() throws Exception {
+        // mock worker client
+        WorkerClient mockWorkerClient = mock(WorkerClient.class);
+        when(mockWorkerClient.getSchema(TEST_STUDY_ID, TEST_SCHEMA_ID, TEST_SCHEMA_REV)).thenReturn(null);
+
+        BridgeHelper bridgeHelper = new BridgeHelper();
+        bridgeHelper.setWorkerClient(mockWorkerClient);
+
+        Metrics metrics = new Metrics();
+
+        // execute and validate
+        try {
+            bridgeHelper.getSchema(metrics, TEST_SCHEMA_KEY);
+            fail("expected exception");
+        } catch (SchemaNotFoundException ex) {
+            // expected exception
+        }
+
+        SortedSetMultimap<String, String> keyValuesMap = metrics.getKeyValuesMap();
+        SortedSet<String> schemasNotFoundSet = keyValuesMap.get("schemasNotFound");
+        assertEquals(schemasNotFoundSet.size(), 1);
+        assertTrue(schemasNotFoundSet.contains(TEST_SCHEMA_KEY.toString()));
+    }
+}

--- a/src/test/java/org/sagebionetworks/bridge/exporter/synapse/SynapseHelperSerializeTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/synapse/SynapseHelperSerializeTest.java
@@ -21,7 +21,7 @@ import org.joda.time.DateTime;
 import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.json.DefaultObjectMapper;
-import org.sagebionetworks.bridge.schema.UploadFieldTypes;
+import org.sagebionetworks.bridge.sdk.models.upload.UploadFieldType;
 
 // Tests for SynapseHelper.serializeToSynapseType()
 public class SynapseHelperSerializeTest {
@@ -33,35 +33,28 @@ public class SynapseHelperSerializeTest {
     @Test
     public void nullValue() throws Exception {
         String retVal = new SynapseHelper().serializeToSynapseType(MOCK_TEMP_DIR, TEST_PROJECT_ID, TEST_RECORD_ID,
-                TEST_FIELD_NAME, UploadFieldTypes.STRING, null);
+                TEST_FIELD_NAME, UploadFieldType.STRING, null);
         assertNull(retVal);
     }
 
     @Test
     public void jsonNull() throws Exception {
         String retVal = new SynapseHelper().serializeToSynapseType(MOCK_TEMP_DIR, TEST_PROJECT_ID, TEST_RECORD_ID,
-                TEST_FIELD_NAME, UploadFieldTypes.STRING, NullNode.instance);
+                TEST_FIELD_NAME, UploadFieldType.STRING, NullNode.instance);
         assertNull(retVal);
-    }
-
-    @Test
-    public void invalidBridgeType() throws Exception {
-        String retVal = new SynapseHelper().serializeToSynapseType(MOCK_TEMP_DIR, TEST_PROJECT_ID, TEST_RECORD_ID,
-                TEST_FIELD_NAME, "BAD_TYPE", new TextNode("bad type value"));
-        assertEquals(retVal, "bad type value");
     }
 
     @Test
     public void booleanTrue() throws Exception {
         String retVal = new SynapseHelper().serializeToSynapseType(MOCK_TEMP_DIR, TEST_PROJECT_ID, TEST_RECORD_ID,
-                TEST_FIELD_NAME, UploadFieldTypes.BOOLEAN, BooleanNode.TRUE);
+                TEST_FIELD_NAME, UploadFieldType.BOOLEAN, BooleanNode.TRUE);
         assertEquals(retVal, "true");
     }
 
     @Test
     public void booleanFalse() throws Exception {
         String retVal = new SynapseHelper().serializeToSynapseType(MOCK_TEMP_DIR, TEST_PROJECT_ID, TEST_RECORD_ID,
-                TEST_FIELD_NAME, UploadFieldTypes.BOOLEAN, BooleanNode.FALSE);
+                TEST_FIELD_NAME, UploadFieldType.BOOLEAN, BooleanNode.FALSE);
         assertEquals(retVal, "false");
     }
 
@@ -69,35 +62,35 @@ public class SynapseHelperSerializeTest {
     public void booleanInvalidType() throws Exception {
         // We don't parse JSON strings. We only accept JSON booleans.
         String retVal = new SynapseHelper().serializeToSynapseType(MOCK_TEMP_DIR, TEST_PROJECT_ID, TEST_RECORD_ID,
-                TEST_FIELD_NAME, UploadFieldTypes.BOOLEAN, new TextNode("true"));
+                TEST_FIELD_NAME, UploadFieldType.BOOLEAN, new TextNode("true"));
         assertNull(retVal);
     }
 
     @Test
     public void calendarDate() throws Exception {
         String retVal = new SynapseHelper().serializeToSynapseType(MOCK_TEMP_DIR, TEST_PROJECT_ID, TEST_RECORD_ID,
-                TEST_FIELD_NAME, UploadFieldTypes.CALENDAR_DATE, new TextNode("2015-12-01"));
+                TEST_FIELD_NAME, UploadFieldType.CALENDAR_DATE, new TextNode("2015-12-01"));
         assertEquals(retVal, "2015-12-01");
     }
 
     @Test
     public void calendarDateMalformatted() throws Exception {
         String retVal = new SynapseHelper().serializeToSynapseType(MOCK_TEMP_DIR, TEST_PROJECT_ID, TEST_RECORD_ID,
-                TEST_FIELD_NAME, UploadFieldTypes.CALENDAR_DATE, new TextNode("foobarbaz"));
+                TEST_FIELD_NAME, UploadFieldType.CALENDAR_DATE, new TextNode("foobarbaz"));
         assertNull(retVal);
     }
 
     @Test
     public void floatValue() throws Exception {
         String retVal = new SynapseHelper().serializeToSynapseType(MOCK_TEMP_DIR, TEST_PROJECT_ID, TEST_RECORD_ID,
-                TEST_FIELD_NAME, UploadFieldTypes.FLOAT, new DecimalNode(new BigDecimal("3.14")));
+                TEST_FIELD_NAME, UploadFieldType.FLOAT, new DecimalNode(new BigDecimal("3.14")));
         assertEquals(retVal, "3.14");
     }
 
     @Test
     public void floatFromInt() throws Exception {
         String retVal = new SynapseHelper().serializeToSynapseType(MOCK_TEMP_DIR, TEST_PROJECT_ID, TEST_RECORD_ID,
-                TEST_FIELD_NAME, UploadFieldTypes.FLOAT, new IntNode(42));
+                TEST_FIELD_NAME, UploadFieldType.FLOAT, new IntNode(42));
         assertEquals(retVal, "42");
     }
 
@@ -105,7 +98,7 @@ public class SynapseHelperSerializeTest {
     public void floatInvalidType() throws Exception {
         // We don't parse JSON strings. We only accept JSON booleans.
         String retVal = new SynapseHelper().serializeToSynapseType(MOCK_TEMP_DIR, TEST_PROJECT_ID, TEST_RECORD_ID,
-                TEST_FIELD_NAME, UploadFieldTypes.FLOAT, new TextNode("3.14"));
+                TEST_FIELD_NAME, UploadFieldType.FLOAT, new TextNode("3.14"));
         assertNull(retVal);
     }
 
@@ -117,7 +110,7 @@ public class SynapseHelperSerializeTest {
 
         // serialize, which basically just copies the JSON text as is
         String retVal = new SynapseHelper().serializeToSynapseType(MOCK_TEMP_DIR, TEST_PROJECT_ID, TEST_RECORD_ID,
-                TEST_FIELD_NAME, UploadFieldTypes.INLINE_JSON_BLOB, originalNode);
+                TEST_FIELD_NAME, UploadFieldType.INLINE_JSON_BLOB, originalNode);
 
         // parse back into JSON and compare
         JsonNode reparsedNode = DefaultObjectMapper.INSTANCE.readTree(retVal);
@@ -132,7 +125,7 @@ public class SynapseHelperSerializeTest {
     @Test
     public void intValue() throws Exception {
         String retVal = new SynapseHelper().serializeToSynapseType(MOCK_TEMP_DIR, TEST_PROJECT_ID, TEST_RECORD_ID,
-                TEST_FIELD_NAME, UploadFieldTypes.INT, new IntNode(42));
+                TEST_FIELD_NAME, UploadFieldType.INT, new IntNode(42));
         assertEquals(retVal, "42");
     }
 
@@ -140,7 +133,7 @@ public class SynapseHelperSerializeTest {
     public void intFromFloat() throws Exception {
         // This simply calls longValue() on the node, which causes truncation instead of rounding.
         String retVal = new SynapseHelper().serializeToSynapseType(MOCK_TEMP_DIR, TEST_PROJECT_ID, TEST_RECORD_ID,
-                TEST_FIELD_NAME, UploadFieldTypes.INT, new DecimalNode(new BigDecimal("-13.9")));
+                TEST_FIELD_NAME, UploadFieldType.INT, new DecimalNode(new BigDecimal("-13.9")));
         assertEquals(retVal, "-13");
     }
 
@@ -148,14 +141,14 @@ public class SynapseHelperSerializeTest {
     public void intInvalidType() throws Exception {
         // We don't parse JSON strings. We only accept JSON booleans.
         String retVal = new SynapseHelper().serializeToSynapseType(MOCK_TEMP_DIR, TEST_PROJECT_ID, TEST_RECORD_ID,
-                TEST_FIELD_NAME, UploadFieldTypes.INT, new TextNode("-13"));
+                TEST_FIELD_NAME, UploadFieldType.INT, new TextNode("-13"));
         assertNull(retVal);
     }
 
     @Test
     public void stringValue() throws Exception {
         String retVal = new SynapseHelper().serializeToSynapseType(MOCK_TEMP_DIR, TEST_PROJECT_ID, TEST_RECORD_ID,
-                TEST_FIELD_NAME, UploadFieldTypes.STRING, new TextNode("foobarbaz"));
+                TEST_FIELD_NAME, UploadFieldType.STRING, new TextNode("foobarbaz"));
         assertEquals(retVal, "foobarbaz");
     }
 
@@ -166,7 +159,7 @@ public class SynapseHelperSerializeTest {
 
         // Synapse timestamps are always epoch milliseconds (long)
         String retVal = new SynapseHelper().serializeToSynapseType(MOCK_TEMP_DIR, TEST_PROJECT_ID, TEST_RECORD_ID,
-                TEST_FIELD_NAME, UploadFieldTypes.TIMESTAMP, new TextNode(timestampString));
+                TEST_FIELD_NAME, UploadFieldType.TIMESTAMP, new TextNode(timestampString));
         assertEquals(retVal, String.valueOf(timestampMillis));
     }
 
@@ -174,21 +167,21 @@ public class SynapseHelperSerializeTest {
     public void timestampInvalidString() throws Exception {
         // We parse strings as ISO timestamps, not as longs.
         String retVal = new SynapseHelper().serializeToSynapseType(MOCK_TEMP_DIR, TEST_PROJECT_ID, TEST_RECORD_ID,
-                TEST_FIELD_NAME, UploadFieldTypes.TIMESTAMP, new TextNode("1234567890"));
+                TEST_FIELD_NAME, UploadFieldType.TIMESTAMP, new TextNode("1234567890"));
         assertNull(retVal);
     }
 
     @Test
     public void timestampLong() throws Exception {
         String retVal = new SynapseHelper().serializeToSynapseType(MOCK_TEMP_DIR, TEST_PROJECT_ID, TEST_RECORD_ID,
-                TEST_FIELD_NAME, UploadFieldTypes.TIMESTAMP, new LongNode(1234567890L));
+                TEST_FIELD_NAME, UploadFieldType.TIMESTAMP, new LongNode(1234567890L));
         assertEquals(retVal, "1234567890");
     }
 
     @Test
     public void timestampInvalidType() throws Exception {
         String retVal = new SynapseHelper().serializeToSynapseType(MOCK_TEMP_DIR, TEST_PROJECT_ID, TEST_RECORD_ID,
-                TEST_FIELD_NAME, UploadFieldTypes.TIMESTAMP, BooleanNode.TRUE);
+                TEST_FIELD_NAME, UploadFieldType.TIMESTAMP, BooleanNode.TRUE);
         assertNull(retVal);
     }
 
@@ -196,7 +189,7 @@ public class SynapseHelperSerializeTest {
     public void attachmentInvalidType() throws Exception {
         // Attachments are strings, which is the attachment ID.
         String retVal = new SynapseHelper().serializeToSynapseType(MOCK_TEMP_DIR, TEST_PROJECT_ID, TEST_RECORD_ID,
-                TEST_FIELD_NAME, UploadFieldTypes.ATTACHMENT_BLOB, new LongNode(1234567890L));
+                TEST_FIELD_NAME, UploadFieldType.ATTACHMENT_BLOB, new LongNode(1234567890L));
         assertNull(retVal);
     }
 
@@ -206,10 +199,10 @@ public class SynapseHelperSerializeTest {
         // of tests, just mock it out.
         SynapseHelper synapseHelper = spy(new SynapseHelper());
         doReturn("dummy-filehandle-id").when(synapseHelper).uploadFromS3ToSynapseFileHandle(MOCK_TEMP_DIR,
-                TEST_PROJECT_ID, TEST_FIELD_NAME, UploadFieldTypes.ATTACHMENT_BLOB, "dummy-attachment-id");
+                TEST_PROJECT_ID, TEST_FIELD_NAME, UploadFieldType.ATTACHMENT_BLOB, "dummy-attachment-id");
 
         String retVal = synapseHelper.serializeToSynapseType(MOCK_TEMP_DIR, TEST_PROJECT_ID, TEST_RECORD_ID,
-                TEST_FIELD_NAME, UploadFieldTypes.ATTACHMENT_BLOB, new TextNode("dummy-attachment-id"));
+                TEST_FIELD_NAME, UploadFieldType.ATTACHMENT_BLOB, new TextNode("dummy-attachment-id"));
         assertEquals(retVal, "dummy-filehandle-id");
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/exporter/synapse/SynapseHelperUploadAttachmentTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/synapse/SynapseHelperUploadAttachmentTest.java
@@ -25,74 +25,74 @@ import org.sagebionetworks.bridge.exporter.config.SpringConfig;
 import org.sagebionetworks.bridge.file.FileHelper;
 import org.sagebionetworks.bridge.file.InMemoryFileHelper;
 import org.sagebionetworks.bridge.s3.S3Helper;
-import org.sagebionetworks.bridge.schema.UploadFieldTypes;
+import org.sagebionetworks.bridge.sdk.models.upload.UploadFieldType;
 
 // Tests for SynapseHelper.uploadFromS3ToSynapseFileHandle() and related methods.
 @SuppressWarnings("unchecked")
 public class SynapseHelperUploadAttachmentTest {
     @Test
     public void filenameJsonBlob() {
-        assertEquals(SynapseHelper.generateFilename("test.json.blob", UploadFieldTypes.ATTACHMENT_JSON_BLOB, "attId"),
+        assertEquals(SynapseHelper.generateFilename("test.json.blob", UploadFieldType.ATTACHMENT_JSON_BLOB, "attId"),
                 "test.json.blob-attId.json");
     }
 
     @Test
     public void filenameJsonTable() {
-        assertEquals(SynapseHelper.generateFilename("test.json.table", UploadFieldTypes.ATTACHMENT_JSON_TABLE,
+        assertEquals(SynapseHelper.generateFilename("test.json.table", UploadFieldType.ATTACHMENT_JSON_TABLE,
                 "attId"), "test.json.table-attId.json");
     }
 
     @Test
     public void filenameJsonWithJsonExtension() {
-        assertEquals(SynapseHelper.generateFilename("test.json", UploadFieldTypes.ATTACHMENT_JSON_BLOB, "attId"),
+        assertEquals(SynapseHelper.generateFilename("test.json", UploadFieldType.ATTACHMENT_JSON_BLOB, "attId"),
                 "test-attId.json");
     }
 
     @Test
     public void filenameCsv() {
-        assertEquals(SynapseHelper.generateFilename("csv.data", UploadFieldTypes.ATTACHMENT_CSV, "attId"),
+        assertEquals(SynapseHelper.generateFilename("csv.data", UploadFieldType.ATTACHMENT_CSV, "attId"),
                 "csv.data-attId.csv");
     }
 
     @Test
     public void filenameCsvWithCsvExtension() {
-        assertEquals(SynapseHelper.generateFilename("data.csv", UploadFieldTypes.ATTACHMENT_CSV, "attId"),
+        assertEquals(SynapseHelper.generateFilename("data.csv", UploadFieldType.ATTACHMENT_CSV, "attId"),
                 "data-attId.csv");
     }
 
     @Test
     public void filenameBlob() {
-        assertEquals(SynapseHelper.generateFilename("generic.blob", UploadFieldTypes.ATTACHMENT_BLOB, "attId"),
+        assertEquals(SynapseHelper.generateFilename("generic.blob", UploadFieldType.ATTACHMENT_BLOB, "attId"),
                 "generic-attId.blob");
     }
 
     @Test
     public void filenameBlobWithNoExtension() {
-        assertEquals(SynapseHelper.generateFilename("genericBlob", UploadFieldTypes.ATTACHMENT_BLOB, "attId"),
+        assertEquals(SynapseHelper.generateFilename("genericBlob", UploadFieldType.ATTACHMENT_BLOB, "attId"),
                 "genericBlob-attId");
     }
 
     @Test
     public void filenameBlobWithMultipleDots() {
-        assertEquals(SynapseHelper.generateFilename("generic.blob.ext", UploadFieldTypes.ATTACHMENT_BLOB, "attId"),
+        assertEquals(SynapseHelper.generateFilename("generic.blob.ext", UploadFieldType.ATTACHMENT_BLOB, "attId"),
                 "generic.blob-attId.ext");
     }
 
     @Test
     public void filenameBlobStartsWithDot() {
-        assertEquals(SynapseHelper.generateFilename(".dot", UploadFieldTypes.ATTACHMENT_BLOB, "attId"),
+        assertEquals(SynapseHelper.generateFilename(".dot", UploadFieldType.ATTACHMENT_BLOB, "attId"),
                 ".dot-attId");
     }
 
     @Test
     public void filenameBlobStartsWithDotWithExtension() {
-        assertEquals(SynapseHelper.generateFilename(".dot.ext", UploadFieldTypes.ATTACHMENT_BLOB, "attId"),
+        assertEquals(SynapseHelper.generateFilename(".dot.ext", UploadFieldType.ATTACHMENT_BLOB, "attId"),
                 ".dot-attId.ext");
     }
 
     @Test
     public void filenameBlobEndsWithDot() {
-        assertEquals(SynapseHelper.generateFilename("dot.dot.", UploadFieldTypes.ATTACHMENT_BLOB, "attId"),
+        assertEquals(SynapseHelper.generateFilename("dot.dot.", UploadFieldType.ATTACHMENT_BLOB, "attId"),
                 "dot.dot.-attId");
     }
 
@@ -138,7 +138,7 @@ public class SynapseHelperUploadAttachmentTest {
 
         // execute and validate
         String fileHandleId = synapseHelper.uploadFromS3ToSynapseFileHandle(tmpDir, TEST_PROJECT_ID, TEST_FIELD_NAME,
-                UploadFieldTypes.ATTACHMENT_BLOB, TEST_ATTACHMENT_ID);
+                UploadFieldType.ATTACHMENT_BLOB, TEST_ATTACHMENT_ID);
         assertEquals(fileHandleId, TEST_FILE_HANDLE_ID);
 
         // validate that SynapseHelper cleans up after itself
@@ -167,7 +167,7 @@ public class SynapseHelperUploadAttachmentTest {
         // execute and validate
         try {
             synapseHelper.uploadFromS3ToSynapseFileHandle(tmpDir, TEST_PROJECT_ID, TEST_FIELD_NAME,
-                    UploadFieldTypes.ATTACHMENT_BLOB, TEST_ATTACHMENT_ID);
+                    UploadFieldType.ATTACHMENT_BLOB, TEST_ATTACHMENT_ID);
             fail("expected exception");
         } catch (SynapseException ex) {
             // expected exception


### PR DESCRIPTION
Currently, BridgeEX gets schemas directly from Dynamo and has its own object model for schemas and fields. This is a problem because it means when we update schemas, we have to change it in one more place.

This change refactors BridgeEX to use BridgeJavaSDK to get schemas and to use the BridgeJavaSDK object model.

Testing done:
- mvn verify (unit tests, findbugs, jacoco test coverage)
- manually tested a simple export

Open questions:
- What happens if this runs continuously for more than 24 hours? Will the Bridge session expire?
