### PR TITLE
Upload v2 field types

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/exporter/handler/HealthDataExportHandler.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/handler/HealthDataExportHandler.java
@@ -5,11 +5,16 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import com.amazonaws.services.dynamodbv2.document.Item;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.TextNode;
+import com.google.common.collect.ImmutableMap;
 import com.jcabi.aspects.Cacheable;
+import org.joda.time.DateTime;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
 import org.sagebionetworks.client.exceptions.SynapseException;
 import org.sagebionetworks.repo.model.table.ColumnModel;
 import org.sagebionetworks.repo.model.table.ColumnType;
@@ -30,6 +35,11 @@ import org.sagebionetworks.bridge.sdk.models.upload.UploadSchema;
 /** Synapse export worker for health data tables. */
 public class HealthDataExportHandler extends SynapseExportHandler {
     private static final Logger LOG = LoggerFactory.getLogger(HealthDataExportHandler.class);
+
+    private static final String TIME_ZONE_FIELD_SUFFIX = ".timezone";
+    private static final long TIME_ZONE_FIELD_LENGTH = 5;
+    private static final DateTimeFormatter TIME_ZONE_FORMATTER = DateTimeFormat.forPattern("Z");
+    private static final String TIME_ZONE_UTC_STRING = "+0000";
 
     private UploadSchema schema;
     private UploadSchemaKey schemaKey;
@@ -64,39 +74,54 @@ public class HealthDataExportHandler extends SynapseExportHandler {
     }
 
     @Override
-    @Cacheable(forever = true)
+    @Cacheable(lifetime = 5, unit = TimeUnit.MINUTES)
     protected List<ColumnModel> getSynapseTableColumnList() {
         List<ColumnModel> columnList = new ArrayList<>();
         for (UploadFieldDefinition oneFieldDef : schema.getFieldDefinitions()) {
             String oneFieldName = oneFieldDef.getName();
             UploadFieldType bridgeType = oneFieldDef.getType();
 
-            ColumnType synapseType = SynapseHelper.BRIDGE_TYPE_TO_SYNAPSE_TYPE.get(bridgeType);
-            if (synapseType == null) {
-                LOG.error("No Synapse type found for Bridge type " + bridgeType);
-                synapseType = ColumnType.STRING;
-            }
+            if (bridgeType == UploadFieldType.MULTI_CHOICE) {
+                throw new UnsupportedOperationException("MULTI_CHOICE not yet implemented");
+            } else if (bridgeType == UploadFieldType.TIMESTAMP) {
+                // Timestamps have 2 columns, one for the timestamp (as a Synapse DATE field) and one for the timezone.
+                ColumnModel timestampColumn = new ColumnModel();
+                timestampColumn.setName(oneFieldName);
+                timestampColumn.setColumnType(ColumnType.DATE);
+                columnList.add(timestampColumn);
 
-            // hack to cover legacy schemas pre-1k char limit on strings. See comments on
-            // shouldConvertFreeformTextToAttachment() for more details.
-            if (BridgeExporterUtil.shouldConvertFreeformTextToAttachment(schemaKey, oneFieldName)) {
-                synapseType = ColumnType.FILEHANDLEID;
-            }
+                ColumnModel timezoneColumn = new ColumnModel();
+                timezoneColumn.setName(oneFieldName + TIME_ZONE_FIELD_SUFFIX);
+                timezoneColumn.setColumnType(ColumnType.STRING);
+                timezoneColumn.setMaximumSize(TIME_ZONE_FIELD_LENGTH);
+                columnList.add(timezoneColumn);
+            } else {
+                ColumnModel oneColumn = new ColumnModel();
+                oneColumn.setName(oneFieldName);
 
-            ColumnModel oneColumn = new ColumnModel();
-            oneColumn.setName(oneFieldName);
-            oneColumn.setColumnType(synapseType);
-
-            if (synapseType == ColumnType.STRING) {
-                Integer maxLength = SynapseHelper.BRIDGE_TYPE_TO_MAX_LENGTH.get(bridgeType);
-                if (maxLength == null) {
-                    LOG.error("No max length found for Bridge type " + bridgeType);
-                    maxLength = SynapseHelper.DEFAULT_MAX_LENGTH;
+                // Special logic for strings.
+                ColumnType synapseType = SynapseHelper.BRIDGE_TYPE_TO_SYNAPSE_TYPE.get(bridgeType);
+                if (synapseType == ColumnType.STRING) {
+                    if (BridgeExporterUtil.shouldConvertFreeformTextToAttachment(schemaKey, oneFieldName)) {
+                        // hack to cover legacy schemas pre-1k char limit on strings. See comments on
+                        // shouldConvertFreeformTextToAttachment() for more details.
+                        oneColumn.setColumnType(ColumnType.FILEHANDLEID);
+                    } else {
+                        // Could be String or LargeText, depending on max length.
+                        int maxLength = SynapseHelper.getMaxLengthForFieldDef(oneFieldDef);
+                        if (maxLength > 1000) {
+                            oneColumn.setColumnType(ColumnType.LARGETEXT);
+                        } else {
+                            oneColumn.setColumnType(ColumnType.STRING);
+                            oneColumn.setMaximumSize((long) maxLength);
+                        }
+                    }
+                } else {
+                    oneColumn.setColumnType(synapseType);
                 }
-                oneColumn.setMaximumSize(Long.valueOf(maxLength));
-            }
 
-            columnList.add(oneColumn);
+                columnList.add(oneColumn);
+            }
         }
 
         return columnList;
@@ -130,7 +155,10 @@ public class HealthDataExportHandler extends SynapseExportHandler {
 
             if (BridgeExporterUtil.shouldConvertFreeformTextToAttachment(schemaKey, oneFieldName)) {
                 // special hack, see comments on shouldConvertFreeformTextToAttachment()
-                bridgeType = UploadFieldType.ATTACHMENT_BLOB;
+                // For the purposes of this hack, the only fields in the field def that matter the field name and type
+                // (attachment).
+                oneFieldDef = new UploadFieldDefinition.Builder().withName(oneFieldName)
+                        .withType(UploadFieldType.ATTACHMENT_V2).build();
                 if (valueNode != null && !valueNode.isNull() && valueNode.isTextual()) {
                     String attachmentId = manager.getExportHelper().uploadFreeformTextAsAttachment(recordId,
                             valueNode.textValue());
@@ -140,11 +168,63 @@ public class HealthDataExportHandler extends SynapseExportHandler {
                 }
             }
 
-            String value = manager.getSynapseHelper().serializeToSynapseType(task.getTmpDir(), synapseProjectId,
-                    recordId, oneFieldName, bridgeType, valueNode);
-            rowValueMap.put(oneFieldName, value);
+            if (bridgeType == UploadFieldType.MULTI_CHOICE) {
+                throw new UnsupportedOperationException("MULTI_CHOICE not yet implemented");
+            } else if (bridgeType == UploadFieldType.TIMESTAMP) {
+                // Similarly, TIMESTAMP serializes into 2 different fields.
+                Map<String, String> serializedTimestampFields = serializeTimestamp(recordId, oneFieldName, valueNode);
+                rowValueMap.putAll(serializedTimestampFields);
+            } else {
+                String value = manager.getSynapseHelper().serializeToSynapseType(task.getTmpDir(), synapseProjectId,
+                        recordId, oneFieldDef, valueNode);
+                rowValueMap.put(oneFieldName, value);
+            }
         }
 
         return rowValueMap;
+    }
+
+    /**
+     * <p>
+     * Serialize a timestamp to a row value map that can be written to a TSV and uploaded to Synapse. The map is a
+     * partial map. The keys are the column names and the values are the row values.
+     * </p>
+     * <p>
+     * Package-scoped to facilitate unit testing.
+     * </p>
+     *
+     * @param recordId
+     *         record ID that corresponds to the row data, used for logging
+     * @param fieldName
+     *         name of timestamp field
+     * @param node
+     *         value of timestamp field
+     * @return partial row value map with serialized timestamp
+     */
+    static Map<String, String> serializeTimestamp(String recordId, String fieldName, JsonNode node) {
+        if (node != null && !node.isNull()) {
+            if (node.isTextual()) {
+                // Timestamp in ISO format. Parse using Joda.
+                String timestampString = node.textValue();
+                try {
+                    DateTime dateTime = DateTime.parse(timestampString);
+                    String epochMillisString = String.valueOf(dateTime.getMillis());
+                    String timeZoneString = TIME_ZONE_FORMATTER.print(dateTime);
+                    return ImmutableMap.<String, String>builder().put(fieldName, epochMillisString)
+                            .put(fieldName + TIME_ZONE_FIELD_SUFFIX, timeZoneString).build();
+                } catch (IllegalArgumentException ex) {
+                    // log an error, but throw out malformatted dates
+                    LOG.error("Invalid timestamp " + timestampString + " for record ID " + recordId);
+                }
+            } else if (node.isNumber()) {
+                // Timestamp is epoch milliseconds. Push this straight across as the timestamp. The timezone is UTC
+                // ("+0000").
+                String epochMillisString = String.valueOf(node.longValue());
+                return ImmutableMap.<String, String>builder().put(fieldName, epochMillisString)
+                        .put(fieldName + TIME_ZONE_FIELD_SUFFIX, TIME_ZONE_UTC_STRING).build();
+            }
+        }
+
+        return ImmutableMap.of();
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/exporter/handler/HealthDataExportHandlerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/handler/HealthDataExportHandlerTest.java
@@ -1,0 +1,81 @@
+package org.sagebionetworks.bridge.exporter.handler;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.node.BooleanNode;
+import com.fasterxml.jackson.databind.node.IntNode;
+import com.fasterxml.jackson.databind.node.NullNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import org.joda.time.DateTime;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class HealthDataExportHandlerTest {
+    private static final String FIELD_NAME = "foo-field";
+    private static final String FIELD_NAME_TIMEZONE = FIELD_NAME + ".timezone";
+
+    // branch coverage
+    @Test
+    public void nullNode() {
+        Map<String, String> rowValueMap = HealthDataExportHandler.serializeTimestamp("dummy", FIELD_NAME, null);
+        assertTrue(rowValueMap.isEmpty());
+    }
+
+    // branch coverage
+    @Test
+    public void javaNull() {
+        Map<String, String> rowValueMap = HealthDataExportHandler.serializeTimestamp("dummy", FIELD_NAME,
+                NullNode.instance);
+        assertTrue(rowValueMap.isEmpty());
+    }
+
+    @Test
+    public void invalidType() {
+        Map<String, String> rowValueMap = HealthDataExportHandler.serializeTimestamp("dummy", FIELD_NAME,
+                BooleanNode.TRUE);
+        assertTrue(rowValueMap.isEmpty());
+    }
+
+    @Test
+    public void malformedTimestampString() {
+        Map<String, String> rowValueMap = HealthDataExportHandler.serializeTimestamp("dummy", FIELD_NAME,
+                new TextNode("Thursday June 9th 2016 @ 4:10pm"));
+        assertTrue(rowValueMap.isEmpty());
+    }
+
+    @DataProvider(name = "timestampStringDataProvider")
+    public Object[][] timestampStringDataProvider() {
+        // { timestampString, expectedTimezoneString }
+        return new Object[][] {
+                { "2016-06-09T12:34:56.789Z", "+0000" },
+                { "2016-06-09T01:02:03.004+0900", "+0900" },
+                { "2016-06-09T02:03:05.007-0700", "-0700" },
+                { "2016-06-09T10:09:08.765+0530", "+0530" },
+        };
+    }
+
+    @Test(dataProvider = "timestampStringDataProvider")
+    public void timestampString(String timestampString, String expectedTimezoneString) {
+        long expectedMillis = DateTime.parse(timestampString).getMillis();
+
+        Map<String, String> rowValueMap = HealthDataExportHandler.serializeTimestamp("dummy", FIELD_NAME,
+                new TextNode(timestampString));
+
+        assertEquals(rowValueMap.size(), 2);
+        assertEquals(rowValueMap.get(FIELD_NAME), String.valueOf(expectedMillis));
+        assertEquals(rowValueMap.get(FIELD_NAME_TIMEZONE), expectedTimezoneString);
+    }
+
+    @Test
+    public void epochMillis() {
+        Map<String, String> rowValueMap = HealthDataExportHandler.serializeTimestamp("dummy", FIELD_NAME,
+                new IntNode(12345));
+
+        assertEquals(rowValueMap.size(), 2);
+        assertEquals(rowValueMap.get(FIELD_NAME), "12345");
+        assertEquals(rowValueMap.get(FIELD_NAME_TIMEZONE), "+0000");
+    }
+}

--- a/src/test/java/org/sagebionetworks/bridge/exporter/handler/SynapseExportHandlerNewTableTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/handler/SynapseExportHandlerNewTableTest.java
@@ -184,7 +184,7 @@ public class SynapseExportHandlerNewTableTest {
 
         // mock serializeToSynapseType() - We actually call through to the real method. Don't need to mock
         // uploadFromS3ToSynapseFileHandle() because we don't have file handles this time.
-        when(mockSynapseHelper.serializeToSynapseType(any(), any(), any(), any(), any(), any())).thenCallRealMethod();
+        when(mockSynapseHelper.serializeToSynapseType(any(), any(), any(), any(), any())).thenCallRealMethod();
 
         // make subtask
         String recordJsonText = "{\n" +

--- a/src/test/java/org/sagebionetworks/bridge/exporter/synapse/SynapseHelperSerializeTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/synapse/SynapseHelperSerializeTest.java
@@ -17,10 +17,11 @@ import com.fasterxml.jackson.databind.node.IntNode;
 import com.fasterxml.jackson.databind.node.LongNode;
 import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.TextNode;
-import org.joda.time.DateTime;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.json.DefaultObjectMapper;
+import org.sagebionetworks.bridge.sdk.models.upload.UploadFieldDefinition;
 import org.sagebionetworks.bridge.sdk.models.upload.UploadFieldType;
 
 // Tests for SynapseHelper.serializeToSynapseType()
@@ -33,28 +34,28 @@ public class SynapseHelperSerializeTest {
     @Test
     public void nullValue() throws Exception {
         String retVal = new SynapseHelper().serializeToSynapseType(MOCK_TEMP_DIR, TEST_PROJECT_ID, TEST_RECORD_ID,
-                TEST_FIELD_NAME, UploadFieldType.STRING, null);
+                fieldDefForType(UploadFieldType.STRING), null);
         assertNull(retVal);
     }
 
     @Test
     public void jsonNull() throws Exception {
         String retVal = new SynapseHelper().serializeToSynapseType(MOCK_TEMP_DIR, TEST_PROJECT_ID, TEST_RECORD_ID,
-                TEST_FIELD_NAME, UploadFieldType.STRING, NullNode.instance);
+                fieldDefForType(UploadFieldType.STRING), NullNode.instance);
         assertNull(retVal);
     }
 
     @Test
     public void booleanTrue() throws Exception {
         String retVal = new SynapseHelper().serializeToSynapseType(MOCK_TEMP_DIR, TEST_PROJECT_ID, TEST_RECORD_ID,
-                TEST_FIELD_NAME, UploadFieldType.BOOLEAN, BooleanNode.TRUE);
+                fieldDefForType(UploadFieldType.BOOLEAN), BooleanNode.TRUE);
         assertEquals(retVal, "true");
     }
 
     @Test
     public void booleanFalse() throws Exception {
         String retVal = new SynapseHelper().serializeToSynapseType(MOCK_TEMP_DIR, TEST_PROJECT_ID, TEST_RECORD_ID,
-                TEST_FIELD_NAME, UploadFieldType.BOOLEAN, BooleanNode.FALSE);
+                fieldDefForType(UploadFieldType.BOOLEAN), BooleanNode.FALSE);
         assertEquals(retVal, "false");
     }
 
@@ -62,35 +63,35 @@ public class SynapseHelperSerializeTest {
     public void booleanInvalidType() throws Exception {
         // We don't parse JSON strings. We only accept JSON booleans.
         String retVal = new SynapseHelper().serializeToSynapseType(MOCK_TEMP_DIR, TEST_PROJECT_ID, TEST_RECORD_ID,
-                TEST_FIELD_NAME, UploadFieldType.BOOLEAN, new TextNode("true"));
+                fieldDefForType(UploadFieldType.BOOLEAN), new TextNode("true"));
         assertNull(retVal);
     }
 
     @Test
     public void calendarDate() throws Exception {
         String retVal = new SynapseHelper().serializeToSynapseType(MOCK_TEMP_DIR, TEST_PROJECT_ID, TEST_RECORD_ID,
-                TEST_FIELD_NAME, UploadFieldType.CALENDAR_DATE, new TextNode("2015-12-01"));
+                fieldDefForType(UploadFieldType.CALENDAR_DATE), new TextNode("2015-12-01"));
         assertEquals(retVal, "2015-12-01");
     }
 
     @Test
-    public void calendarDateMalformatted() throws Exception {
+    public void duration() throws Exception {
         String retVal = new SynapseHelper().serializeToSynapseType(MOCK_TEMP_DIR, TEST_PROJECT_ID, TEST_RECORD_ID,
-                TEST_FIELD_NAME, UploadFieldType.CALENDAR_DATE, new TextNode("foobarbaz"));
-        assertNull(retVal);
+                fieldDefForType(UploadFieldType.DURATION_V2), new TextNode("PT1H"));
+        assertEquals(retVal, "PT1H");
     }
 
     @Test
     public void floatValue() throws Exception {
         String retVal = new SynapseHelper().serializeToSynapseType(MOCK_TEMP_DIR, TEST_PROJECT_ID, TEST_RECORD_ID,
-                TEST_FIELD_NAME, UploadFieldType.FLOAT, new DecimalNode(new BigDecimal("3.14")));
+                fieldDefForType(UploadFieldType.FLOAT), new DecimalNode(new BigDecimal("3.14")));
         assertEquals(retVal, "3.14");
     }
 
     @Test
     public void floatFromInt() throws Exception {
         String retVal = new SynapseHelper().serializeToSynapseType(MOCK_TEMP_DIR, TEST_PROJECT_ID, TEST_RECORD_ID,
-                TEST_FIELD_NAME, UploadFieldType.FLOAT, new IntNode(42));
+                fieldDefForType(UploadFieldType.FLOAT), new IntNode(42));
         assertEquals(retVal, "42");
     }
 
@@ -98,7 +99,7 @@ public class SynapseHelperSerializeTest {
     public void floatInvalidType() throws Exception {
         // We don't parse JSON strings. We only accept JSON booleans.
         String retVal = new SynapseHelper().serializeToSynapseType(MOCK_TEMP_DIR, TEST_PROJECT_ID, TEST_RECORD_ID,
-                TEST_FIELD_NAME, UploadFieldType.FLOAT, new TextNode("3.14"));
+                fieldDefForType(UploadFieldType.FLOAT), new TextNode("3.14"));
         assertNull(retVal);
     }
 
@@ -110,7 +111,7 @@ public class SynapseHelperSerializeTest {
 
         // serialize, which basically just copies the JSON text as is
         String retVal = new SynapseHelper().serializeToSynapseType(MOCK_TEMP_DIR, TEST_PROJECT_ID, TEST_RECORD_ID,
-                TEST_FIELD_NAME, UploadFieldType.INLINE_JSON_BLOB, originalNode);
+                fieldDefForType(UploadFieldType.INLINE_JSON_BLOB), originalNode);
 
         // parse back into JSON and compare
         JsonNode reparsedNode = DefaultObjectMapper.INSTANCE.readTree(retVal);
@@ -125,7 +126,7 @@ public class SynapseHelperSerializeTest {
     @Test
     public void intValue() throws Exception {
         String retVal = new SynapseHelper().serializeToSynapseType(MOCK_TEMP_DIR, TEST_PROJECT_ID, TEST_RECORD_ID,
-                TEST_FIELD_NAME, UploadFieldType.INT, new IntNode(42));
+                fieldDefForType(UploadFieldType.INT), new IntNode(42));
         assertEquals(retVal, "42");
     }
 
@@ -133,7 +134,7 @@ public class SynapseHelperSerializeTest {
     public void intFromFloat() throws Exception {
         // This simply calls longValue() on the node, which causes truncation instead of rounding.
         String retVal = new SynapseHelper().serializeToSynapseType(MOCK_TEMP_DIR, TEST_PROJECT_ID, TEST_RECORD_ID,
-                TEST_FIELD_NAME, UploadFieldType.INT, new DecimalNode(new BigDecimal("-13.9")));
+                fieldDefForType(UploadFieldType.INT), new DecimalNode(new BigDecimal("-13.9")));
         assertEquals(retVal, "-13");
     }
 
@@ -141,68 +142,107 @@ public class SynapseHelperSerializeTest {
     public void intInvalidType() throws Exception {
         // We don't parse JSON strings. We only accept JSON booleans.
         String retVal = new SynapseHelper().serializeToSynapseType(MOCK_TEMP_DIR, TEST_PROJECT_ID, TEST_RECORD_ID,
-                TEST_FIELD_NAME, UploadFieldType.INT, new TextNode("-13"));
+                fieldDefForType(UploadFieldType.INT), new TextNode("-13"));
         assertNull(retVal);
     }
 
-    @Test
-    public void stringValue() throws Exception {
+    @DataProvider(name = "stringTypeProvider")
+    public Object[][] stringTypeProvider() {
+        return new Object[][] {
+                { UploadFieldType.SINGLE_CHOICE },
+                { UploadFieldType.STRING },
+        };
+    }
+
+    @Test(dataProvider = "stringTypeProvider")
+    public void stringValue(UploadFieldType stringType) throws Exception {
         String retVal = new SynapseHelper().serializeToSynapseType(MOCK_TEMP_DIR, TEST_PROJECT_ID, TEST_RECORD_ID,
-                TEST_FIELD_NAME, UploadFieldType.STRING, new TextNode("foobarbaz"));
+                fieldDefForType(stringType), new TextNode("foobarbaz"));
         assertEquals(retVal, "foobarbaz");
     }
 
-    @Test
-    public void timestampString() throws Exception {
-        String timestampString = "2015-12-02T12:15-0800";
-        long timestampMillis = DateTime.parse(timestampString).getMillis();
+    @Test(dataProvider = "stringTypeProvider")
+    public void stringSanitized(UploadFieldType stringType) throws Exception {
+        // Use an extra short field def.
+        UploadFieldDefinition fieldDef = new UploadFieldDefinition.Builder().withName(TEST_FIELD_NAME)
+                .withType(stringType).withMaxLength(10).build();
 
-        // Synapse timestamps are always epoch milliseconds (long)
+        // String value has newlines and tabs that need to be stripped out.
+        String input = "asdf\njkl;\tlorem ipsum dolor";
         String retVal = new SynapseHelper().serializeToSynapseType(MOCK_TEMP_DIR, TEST_PROJECT_ID, TEST_RECORD_ID,
-                TEST_FIELD_NAME, UploadFieldType.TIMESTAMP, new TextNode(timestampString));
-        assertEquals(retVal, String.valueOf(timestampMillis));
+                fieldDef, new TextNode(input));
+
+        // Newlines turned into spaces, string truncated to length 10
+        assertEquals(retVal, "asdf jkl; ");
+    }
+
+    @Test(dataProvider = "stringTypeProvider")
+    public void stringStripHtml(UploadFieldType stringType) throws Exception {
+        String input = "<a href=\"sagebase.org\">link</a>";
+        String retVal = new SynapseHelper().serializeToSynapseType(MOCK_TEMP_DIR, TEST_PROJECT_ID, TEST_RECORD_ID,
+                fieldDefForType(stringType), new TextNode(input));
+        assertEquals(retVal, "link");
     }
 
     @Test
-    public void timestampInvalidString() throws Exception {
-        // We parse strings as ISO timestamps, not as longs.
+    public void time() throws Exception {
         String retVal = new SynapseHelper().serializeToSynapseType(MOCK_TEMP_DIR, TEST_PROJECT_ID, TEST_RECORD_ID,
-                TEST_FIELD_NAME, UploadFieldType.TIMESTAMP, new TextNode("1234567890"));
-        assertNull(retVal);
+                fieldDefForType(UploadFieldType.TIME_V2), new TextNode("13:07:56.123"));
+        assertEquals(retVal, "13:07:56.123");
     }
 
-    @Test
-    public void timestampLong() throws Exception {
-        String retVal = new SynapseHelper().serializeToSynapseType(MOCK_TEMP_DIR, TEST_PROJECT_ID, TEST_RECORD_ID,
-                TEST_FIELD_NAME, UploadFieldType.TIMESTAMP, new LongNode(1234567890L));
-        assertEquals(retVal, "1234567890");
+    @DataProvider(name = "attachmentTypeProvider")
+    public Object[][] attachmentTypeProvider() {
+        return new Object[][] {
+                { UploadFieldType.ATTACHMENT_BLOB },
+                { UploadFieldType.ATTACHMENT_CSV },
+                { UploadFieldType.ATTACHMENT_JSON_BLOB },
+                { UploadFieldType.ATTACHMENT_JSON_TABLE },
+                { UploadFieldType.ATTACHMENT_V2 },
+        };
     }
 
-    @Test
-    public void timestampInvalidType() throws Exception {
-        String retVal = new SynapseHelper().serializeToSynapseType(MOCK_TEMP_DIR, TEST_PROJECT_ID, TEST_RECORD_ID,
-                TEST_FIELD_NAME, UploadFieldType.TIMESTAMP, BooleanNode.TRUE);
-        assertNull(retVal);
-    }
-
-    @Test
-    public void attachmentInvalidType() throws Exception {
+    @Test(dataProvider = "attachmentTypeProvider")
+    public void attachmentInvalidType(UploadFieldType attachmentType) throws Exception {
         // Attachments are strings, which is the attachment ID.
         String retVal = new SynapseHelper().serializeToSynapseType(MOCK_TEMP_DIR, TEST_PROJECT_ID, TEST_RECORD_ID,
-                TEST_FIELD_NAME, UploadFieldType.ATTACHMENT_BLOB, new LongNode(1234567890L));
+                fieldDefForType(attachmentType), new LongNode(1234567890L));
         assertNull(retVal);
     }
 
-    @Test
-    public void attachment() throws Exception {
+    @Test(dataProvider = "attachmentTypeProvider")
+    public void attachment(UploadFieldType attachmentType) throws Exception {
+        UploadFieldDefinition attachmentFieldDef = fieldDefForType(attachmentType);
+
         // Spy uploadFromS3ToSynapseFileHandle(). This has some complex logic that is tested elsewhere. For simplicity
         // of tests, just mock it out.
         SynapseHelper synapseHelper = spy(new SynapseHelper());
         doReturn("dummy-filehandle-id").when(synapseHelper).uploadFromS3ToSynapseFileHandle(MOCK_TEMP_DIR,
-                TEST_PROJECT_ID, TEST_FIELD_NAME, UploadFieldType.ATTACHMENT_BLOB, "dummy-attachment-id");
+                TEST_PROJECT_ID, attachmentFieldDef, "dummy-attachment-id");
 
         String retVal = synapseHelper.serializeToSynapseType(MOCK_TEMP_DIR, TEST_PROJECT_ID, TEST_RECORD_ID,
-                TEST_FIELD_NAME, UploadFieldType.ATTACHMENT_BLOB, new TextNode("dummy-attachment-id"));
+                attachmentFieldDef, new TextNode("dummy-attachment-id"));
         assertEquals(retVal, "dummy-filehandle-id");
+    }
+
+    // These types are not supported by serialize() because they serialize into multiple columns.
+    @DataProvider(name = "unsupportedTypeProvider")
+    public Object[][] unsupportedTypeProvider() {
+        return new Object[][] {
+                { UploadFieldType.MULTI_CHOICE },
+                { UploadFieldType.TIMESTAMP },
+        };
+    }
+
+    // This test is mainly for branch coverage. This code path should never be hit in real life.
+    @Test(dataProvider = "unsupportedTypeProvider")
+    public void unsupportedType(UploadFieldType unsupportedType) throws Exception {
+        String retVal = new SynapseHelper().serializeToSynapseType(MOCK_TEMP_DIR, TEST_PROJECT_ID, TEST_RECORD_ID,
+                fieldDefForType(unsupportedType), new TextNode("value doesn't matter"));
+        assertNull(retVal);
+    }
+
+    private static UploadFieldDefinition fieldDefForType(UploadFieldType type) {
+        return new UploadFieldDefinition.Builder().withName(TEST_FIELD_NAME).withType(type).build();
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/exporter/synapse/SynapseHelperTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/synapse/SynapseHelperTest.java
@@ -29,10 +29,41 @@ import org.sagebionetworks.repo.model.table.CsvTableDescriptor;
 import org.sagebionetworks.repo.model.table.RowSet;
 import org.sagebionetworks.repo.model.table.TableEntity;
 import org.sagebionetworks.repo.model.table.UploadToTableResult;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+
+import org.sagebionetworks.bridge.sdk.models.upload.UploadFieldDefinition;
+import org.sagebionetworks.bridge.sdk.models.upload.UploadFieldType;
 
 @SuppressWarnings({ "unchecked", "rawtypes" })
 public class SynapseHelperTest {
+    @DataProvider
+    public Object[][] maxLengthTestDataProvider() {
+        // { fieldDef, expectedMaxLength }
+        return new Object[][] {
+                { new UploadFieldDefinition.Builder().withName("dummy").withType(UploadFieldType.CALENDAR_DATE)
+                        .build(), 10 },
+                { new UploadFieldDefinition.Builder().withName("dummy").withType(UploadFieldType.DURATION_V2).build(),
+                        24 },
+                { new UploadFieldDefinition.Builder().withName("dummy").withType(UploadFieldType.INLINE_JSON_BLOB)
+                        .build(), 100 },
+                { new UploadFieldDefinition.Builder().withName("dummy").withType(UploadFieldType.SINGLE_CHOICE)
+                        .build(), 100 },
+                { new UploadFieldDefinition.Builder().withName("dummy").withType(UploadFieldType.STRING).build(),
+                        100 },
+                { new UploadFieldDefinition.Builder().withName("dummy").withType(UploadFieldType.TIME_V2).build(),
+                        12 },
+                { new UploadFieldDefinition.Builder().withName("dummy").withType(UploadFieldType.STRING)
+                        .withMaxLength(256).build(), 256 },
+        };
+    }
+
+    @Test(dataProvider = "maxLengthTestDataProvider")
+    public void getMaxLengthForFieldDef(UploadFieldDefinition fieldDef, int expectedMaxLength) {
+        int retVal = SynapseHelper.getMaxLengthForFieldDef(fieldDef);
+        assertEquals(retVal, expectedMaxLength);
+    }
+
     // Most of these are retry wrappers, but we should test them anyway for branch coverage.
 
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/exporter/synapse/SynapseHelperUploadAttachmentTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/synapse/SynapseHelperUploadAttachmentTest.java
@@ -18,6 +18,7 @@ import org.sagebionetworks.client.SynapseClient;
 import org.sagebionetworks.client.exceptions.SynapseClientException;
 import org.sagebionetworks.client.exceptions.SynapseException;
 import org.sagebionetworks.repo.model.file.FileHandle;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.config.Config;
@@ -25,87 +26,124 @@ import org.sagebionetworks.bridge.exporter.config.SpringConfig;
 import org.sagebionetworks.bridge.file.FileHelper;
 import org.sagebionetworks.bridge.file.InMemoryFileHelper;
 import org.sagebionetworks.bridge.s3.S3Helper;
+import org.sagebionetworks.bridge.sdk.models.upload.UploadFieldDefinition;
 import org.sagebionetworks.bridge.sdk.models.upload.UploadFieldType;
 
 // Tests for SynapseHelper.uploadFromS3ToSynapseFileHandle() and related methods.
 @SuppressWarnings("unchecked")
 public class SynapseHelperUploadAttachmentTest {
+    private static final String TEST_ATTACHMENT_ID = "attId";
+
+    @Test
+    public void filenameFromFieldDef() {
+        UploadFieldDefinition fieldDef = new UploadFieldDefinition.Builder().withName("test.foo")
+                .withType(UploadFieldType.ATTACHMENT_V2).withFileExtension(".foo").build();
+        String filename = SynapseHelper.generateFilename(fieldDef, TEST_ATTACHMENT_ID);
+        assertEquals(filename, "test-attId.foo");
+    }
+
+    @Test
+    public void filenameFromFieldDefMismatchedExtension() {
+        UploadFieldDefinition fieldDef = new UploadFieldDefinition.Builder().withName("test.bar")
+                .withType(UploadFieldType.ATTACHMENT_V2).withFileExtension(".foo").build();
+        String filename = SynapseHelper.generateFilename(fieldDef, TEST_ATTACHMENT_ID);
+        assertEquals(filename, "test.bar-attId.foo");
+    }
+
     @Test
     public void filenameJsonBlob() {
-        assertEquals(SynapseHelper.generateFilename("test.json.blob", UploadFieldType.ATTACHMENT_JSON_BLOB, "attId"),
-                "test.json.blob-attId.json");
+        assertEquals(SynapseHelper.generateFilename(new UploadFieldDefinition.Builder().withName("test.json.blob")
+            .withType(UploadFieldType.ATTACHMENT_JSON_BLOB).build(), TEST_ATTACHMENT_ID), "test.json.blob-attId.json");
     }
 
     @Test
     public void filenameJsonTable() {
-        assertEquals(SynapseHelper.generateFilename("test.json.table", UploadFieldType.ATTACHMENT_JSON_TABLE,
-                "attId"), "test.json.table-attId.json");
+        assertEquals(SynapseHelper.generateFilename(new UploadFieldDefinition.Builder().withName("test.json.table")
+                        .withType(UploadFieldType.ATTACHMENT_JSON_TABLE).build(), TEST_ATTACHMENT_ID),
+                "test.json.table-attId.json");
     }
 
     @Test
     public void filenameJsonWithJsonExtension() {
-        assertEquals(SynapseHelper.generateFilename("test.json", UploadFieldType.ATTACHMENT_JSON_BLOB, "attId"),
-                "test-attId.json");
+        assertEquals(SynapseHelper.generateFilename(new UploadFieldDefinition.Builder().withName("test.json")
+                .withType(UploadFieldType.ATTACHMENT_JSON_BLOB).build(), TEST_ATTACHMENT_ID), "test-attId.json");
     }
 
     @Test
     public void filenameCsv() {
-        assertEquals(SynapseHelper.generateFilename("csv.data", UploadFieldType.ATTACHMENT_CSV, "attId"),
-                "csv.data-attId.csv");
+        assertEquals(SynapseHelper.generateFilename(new UploadFieldDefinition.Builder().withName("csv.data")
+                .withType(UploadFieldType.ATTACHMENT_CSV).build(), TEST_ATTACHMENT_ID), "csv.data-attId.csv");
     }
 
     @Test
     public void filenameCsvWithCsvExtension() {
-        assertEquals(SynapseHelper.generateFilename("data.csv", UploadFieldType.ATTACHMENT_CSV, "attId"),
-                "data-attId.csv");
+        assertEquals(SynapseHelper.generateFilename(new UploadFieldDefinition.Builder().withName("data.csv")
+                .withType(UploadFieldType.ATTACHMENT_CSV).build(), TEST_ATTACHMENT_ID), "data-attId.csv");
     }
 
     @Test
     public void filenameBlob() {
-        assertEquals(SynapseHelper.generateFilename("generic.blob", UploadFieldType.ATTACHMENT_BLOB, "attId"),
-                "generic-attId.blob");
+        assertEquals(SynapseHelper.generateFilename(new UploadFieldDefinition.Builder().withName("generic.blob")
+                .withType(UploadFieldType.ATTACHMENT_BLOB).build(), TEST_ATTACHMENT_ID), "generic-attId.blob");
     }
 
     @Test
     public void filenameBlobWithNoExtension() {
-        assertEquals(SynapseHelper.generateFilename("genericBlob", UploadFieldType.ATTACHMENT_BLOB, "attId"),
-                "genericBlob-attId");
+        assertEquals(SynapseHelper.generateFilename(new UploadFieldDefinition.Builder().withName("genericBlob")
+                .withType(UploadFieldType.ATTACHMENT_BLOB).build(), TEST_ATTACHMENT_ID), "genericBlob-attId");
     }
 
     @Test
     public void filenameBlobWithMultipleDots() {
-        assertEquals(SynapseHelper.generateFilename("generic.blob.ext", UploadFieldType.ATTACHMENT_BLOB, "attId"),
-                "generic.blob-attId.ext");
+        assertEquals(SynapseHelper.generateFilename(new UploadFieldDefinition.Builder().withName("generic.blob.ext")
+                .withType(UploadFieldType.ATTACHMENT_BLOB).build(), TEST_ATTACHMENT_ID), "generic.blob-attId.ext");
     }
 
     @Test
     public void filenameBlobStartsWithDot() {
-        assertEquals(SynapseHelper.generateFilename(".dot", UploadFieldType.ATTACHMENT_BLOB, "attId"),
-                ".dot-attId");
+        assertEquals(SynapseHelper.generateFilename(new UploadFieldDefinition.Builder().withName(".dot")
+                .withType(UploadFieldType.ATTACHMENT_BLOB).build(), TEST_ATTACHMENT_ID), ".dot-attId");
     }
 
     @Test
     public void filenameBlobStartsWithDotWithExtension() {
-        assertEquals(SynapseHelper.generateFilename(".dot.ext", UploadFieldType.ATTACHMENT_BLOB, "attId"),
-                ".dot-attId.ext");
+        assertEquals(SynapseHelper.generateFilename(new UploadFieldDefinition.Builder().withName(".dot.ext")
+                .withType(UploadFieldType.ATTACHMENT_BLOB).build(), TEST_ATTACHMENT_ID), ".dot-attId.ext");
     }
 
     @Test
     public void filenameBlobEndsWithDot() {
-        assertEquals(SynapseHelper.generateFilename("dot.dot.", UploadFieldType.ATTACHMENT_BLOB, "attId"),
-                "dot.dot.-attId");
+        assertEquals(SynapseHelper.generateFilename(new UploadFieldDefinition.Builder().withName("dot.dot.")
+                .withType(UploadFieldType.ATTACHMENT_BLOB).build(), TEST_ATTACHMENT_ID), "dot.dot.-attId");
     }
 
     private static final String DUMMY_FILE_CONTENT = "This is some file content.";
-    private static final String EXPECTED_FILE_NAME = "test-attachment-id.blob";
-    private static final String TEST_ATTACHMENT_ID = "attachment-id";
     private static final String TEST_ATTACHMENTS_BUCKET = "attachments-bucket";
-    private static final String TEST_FIELD_NAME = "test.blob";
     private static final String TEST_FILE_HANDLE_ID = "file-handle-id";
     private static final String TEST_PROJECT_ID = "project-id";
 
-    @Test
-    public void uploadTest() throws Exception {
+    @DataProvider(name = "uploadTestDataProvider")
+    public Object[][] uploadTestDataProvider() {
+        // { fieldDef, expectedFilename, expectedMimeType }
+        return new Object[][] {
+                { new UploadFieldDefinition.Builder().withName("foo.blob").withType(UploadFieldType.ATTACHMENT_BLOB)
+                        .build(), "foo-attId.blob", "application/octet-stream" },
+                { new UploadFieldDefinition.Builder().withName("bar.csv").withType(UploadFieldType.ATTACHMENT_CSV)
+                        .build(), "bar-attId.csv", "text/csv" },
+                { new UploadFieldDefinition.Builder().withName("baz.json")
+                        .withType(UploadFieldType.ATTACHMENT_JSON_BLOB).build(), "baz-attId.json", "text/json" },
+                { new UploadFieldDefinition.Builder().withName("qwerty.json")
+                        .withType(UploadFieldType.ATTACHMENT_JSON_TABLE).build(), "qwerty-attId.json", "text/json" },
+                { new UploadFieldDefinition.Builder().withName("asdf.file").withType(UploadFieldType.ATTACHMENT_V2)
+                        .build(), "asdf-attId.file", "application/octet-stream" },
+                { new UploadFieldDefinition.Builder().withName("jkl.txt").withType(UploadFieldType.ATTACHMENT_V2)
+                        .withFileExtension(".txt").withMimeType("text/plain").build(), "jkl-attId.txt", "text/plain" },
+        };
+    }
+
+    @Test(dataProvider = "uploadTestDataProvider")
+    public void uploadTest(UploadFieldDefinition fieldDef, String expectedFilename, String expectedMimeType)
+            throws Exception {
         // mock (in-memory) file helper
         InMemoryFileHelper mockFileHelper = new InMemoryFileHelper();
         File tmpDir = mockFileHelper.createTempDir();
@@ -113,11 +151,11 @@ public class SynapseHelperUploadAttachmentTest {
         // Mock Synapse client. Since we delete the file immediately afterwards, use a mock answer to validate file
         // contents.
         SynapseClient mockSynapseClient = mock(SynapseClient.class);
-        when(mockSynapseClient.createFileHandle(any(), eq("application/octet-stream"), eq(TEST_PROJECT_ID)))
+        when(mockSynapseClient.createFileHandle(any(), eq(expectedMimeType), eq(TEST_PROJECT_ID)))
                 .thenAnswer(invocation -> {
                     // validate file name and contents
                     File file = invocation.getArgumentAt(0, File.class);
-                    assertEquals(file.getName(), EXPECTED_FILE_NAME);
+                    assertEquals(file.getName(), expectedFilename);
                     try (Reader fileReader = mockFileHelper.getReader(file)) {
                         String fileContent = CharStreams.toString(fileReader);
                         assertEquals(fileContent, DUMMY_FILE_CONTENT);
@@ -133,12 +171,12 @@ public class SynapseHelperUploadAttachmentTest {
         SynapseHelper synapseHelper = new SynapseHelper();
         synapseHelper.setConfig(mockConfig());
         synapseHelper.setFileHelper(mockFileHelper);
-        synapseHelper.setS3Helper(mockS3Helper(mockFileHelper));
+        synapseHelper.setS3Helper(mockS3Helper(mockFileHelper, expectedFilename));
         synapseHelper.setSynapseClient(mockSynapseClient);
 
         // execute and validate
-        String fileHandleId = synapseHelper.uploadFromS3ToSynapseFileHandle(tmpDir, TEST_PROJECT_ID, TEST_FIELD_NAME,
-                UploadFieldType.ATTACHMENT_BLOB, TEST_ATTACHMENT_ID);
+        String fileHandleId = synapseHelper.uploadFromS3ToSynapseFileHandle(tmpDir, TEST_PROJECT_ID,
+                fieldDef, TEST_ATTACHMENT_ID);
         assertEquals(fileHandleId, TEST_FILE_HANDLE_ID);
 
         // validate that SynapseHelper cleans up after itself
@@ -161,13 +199,13 @@ public class SynapseHelperUploadAttachmentTest {
         SynapseHelper synapseHelper = new SynapseHelper();
         synapseHelper.setConfig(mockConfig());
         synapseHelper.setFileHelper(mockFileHelper);
-        synapseHelper.setS3Helper(mockS3Helper(mockFileHelper));
+        synapseHelper.setS3Helper(mockS3Helper(mockFileHelper, "test-attId.blob"));
         synapseHelper.setSynapseClient(mockSynapseClient);
 
         // execute and validate
         try {
-            synapseHelper.uploadFromS3ToSynapseFileHandle(tmpDir, TEST_PROJECT_ID, TEST_FIELD_NAME,
-                    UploadFieldType.ATTACHMENT_BLOB, TEST_ATTACHMENT_ID);
+            synapseHelper.uploadFromS3ToSynapseFileHandle(tmpDir, TEST_PROJECT_ID, new UploadFieldDefinition.Builder()
+                    .withName("test.blob").withType(UploadFieldType.ATTACHMENT_BLOB).build(), TEST_ATTACHMENT_ID);
             fail("expected exception");
         } catch (SynapseException ex) {
             // expected exception
@@ -184,12 +222,12 @@ public class SynapseHelperUploadAttachmentTest {
         return mockConfig;
     }
 
-    private static S3Helper mockS3Helper(FileHelper mockFileHelper) {
+    private static S3Helper mockS3Helper(FileHelper mockFileHelper, String expectedFilename) {
         S3Helper mockS3Helper = mock(S3Helper.class);
         doAnswer(invocation -> {
             // write to file to simulate an actual download
             File destFile = invocation.getArgumentAt(2, File.class);
-            assertEquals(destFile.getName(), EXPECTED_FILE_NAME);
+            assertEquals(destFile.getName(), expectedFilename);
             try (Writer destFileWriter = mockFileHelper.getWriter(destFile)) {
                 destFileWriter.write(DUMMY_FILE_CONTENT);
             }


### PR DESCRIPTION
Includes the new field types listed in https://sagebionetworks.jira.com/wiki/display/BRIDGE/Upload+Format+v2#UploadFormatv2-Subtask1a:FieldTypes with the sole exception of MULTI_CHOICE, which is missing because I forgot to add important logic to the server.

Testing done:
- added and updated unit tests
- mvn verify (unit tests, findbugs, Jacoco coverage)
- manual test, a new schema and Synapse table that includes: short string, long strong (blob / large text), int, timestamp (date-time), and attachment (w/ new fields)
