### PR TITLE
add unbounded text support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <dependency>
             <groupId>org.sagebionetworks.bridge</groupId>
             <artifactId>java-sdk</artifactId>
-            <version>0.8.11</version>
+            <version>0.8.13</version>
         </dependency>
         <dependency>
             <groupId>org.sagebionetworks</groupId>

--- a/src/main/java/org/sagebionetworks/bridge/exporter/handler/HealthDataExportHandler.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/handler/HealthDataExportHandler.java
@@ -120,8 +120,9 @@ public class HealthDataExportHandler extends SynapseExportHandler {
                         oneColumn.setColumnType(ColumnType.FILEHANDLEID);
                     } else {
                         // Could be String or LargeText, depending on max length.
+                        Boolean isUnboundedText = oneFieldDef.isUnboundedText();
                         int maxLength = SynapseHelper.getMaxLengthForFieldDef(oneFieldDef);
-                        if (maxLength > 1000) {
+                        if ((isUnboundedText != null && isUnboundedText) || maxLength > 1000) {
                             oneColumn.setColumnType(ColumnType.LARGETEXT);
                         } else {
                             oneColumn.setColumnType(ColumnType.STRING);

--- a/src/main/java/org/sagebionetworks/bridge/exporter/synapse/SynapseHelper.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/synapse/SynapseHelper.java
@@ -215,7 +215,13 @@ public class SynapseHelper {
                     // Some types (notably INLINE_JSON_BLOB) will use the whole JSON value.
                     nodeValue = node.toString();
                 }
-                Integer maxLength = getMaxLengthForFieldDef(fieldDef);
+
+                Boolean isUnboundedText = fieldDef.isUnboundedText();
+                Integer maxLength = null;
+                if (isUnboundedText == null || !isUnboundedText) {
+                    maxLength = getMaxLengthForFieldDef(fieldDef);
+                }
+
                 String sanitizedValue = BridgeExporterUtil.sanitizeString(nodeValue, maxLength, recordId);
                 return sanitizedValue;
             }

--- a/src/main/java/org/sagebionetworks/bridge/exporter/util/BridgeExporterUtil.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/util/BridgeExporterUtil.java
@@ -135,12 +135,12 @@ public class BridgeExporterUtil {
      * @param in
      *         value to sanitize
      * @param maxLength
-     *         max length of the column
+     *         max length of the column, null if the string can be unbounded
      * @param recordId
      *         record ID, for logging purposes
      * @return sanitized string
      */
-    public static String sanitizeString(String in, int maxLength, String recordId) {
+    public static String sanitizeString(String in, Integer maxLength, String recordId) {
         if (in == null) {
             return null;
         }
@@ -152,7 +152,7 @@ public class BridgeExporterUtil {
         in = in.replaceAll("[\n\r\t]+", " ");
 
         // Check against max length, truncating and warning as necessary.
-        if (in.length() > maxLength) {
+        if (maxLength != null && in.length() > maxLength) {
             LOG.error("Truncating string " + in + " to length " + maxLength + " for record " + recordId);
             in = in.substring(0, maxLength);
         }

--- a/src/test/java/org/sagebionetworks/bridge/exporter/handler/SynapseExportHandlerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/handler/SynapseExportHandlerTest.java
@@ -293,6 +293,8 @@ public class SynapseExportHandlerTest {
                                 .withMaxLength(20).build(),
                         new UploadFieldDefinition.Builder().withName("foooo").withType(UploadFieldType.STRING)
                                 .withMaxLength(9999).build(),
+                        new UploadFieldDefinition.Builder().withName("unbounded-foo").withType(UploadFieldType.STRING)
+                                .withUnboundedText(true).build(),
                         new UploadFieldDefinition.Builder().withName("bar").withType(UploadFieldType.INT).build(),
                         new UploadFieldDefinition.Builder().withName("submitTime").withType(UploadFieldType.TIMESTAMP)
                                 .build(),
@@ -331,6 +333,7 @@ public class SynapseExportHandlerTest {
         String recordJsonText = "{\n" +
                 "   \"foo\":\"This is a string.\",\n" +
                 "   \"foooo\":\"Example (not) long string\",\n" +
+                "   \"unbounded-foo\":\"Potentially unbounded string\",\n" +
                 "   \"bar\":42,\n" +
                 "   \"submitTime\":\"" + submitTimeStr + "\",\n" +
                 "   \"sports\":[\"fencing\", \"running\"],\n" +
@@ -345,10 +348,12 @@ public class SynapseExportHandlerTest {
         // validate tsv file
         List<String> tsvLineList = TestUtil.bytesToLines(tsvBytes);
         assertEquals(tsvLineList.size(), 2);
-        validateTsvHeaders(tsvLineList.get(0), "foo", "foooo", "bar", "submitTime", "submitTime.timezone",
-                "sports.fencing", "sports.football", "sports.running", "sports.swimming", FREEFORM_FIELD_NAME);
-        validateTsvRow(tsvLineList.get(1), "This is a string.", "Example (not) long string", "42",
-                String.valueOf(submitTimeMillis), "+0900", "true", "false", "true", "false", DUMMY_FILEHANDLE_ID);
+        validateTsvHeaders(tsvLineList.get(0), "foo", "foooo", "unbounded-foo", "bar", "submitTime",
+                "submitTime.timezone", "sports.fencing", "sports.football", "sports.running", "sports.swimming",
+                FREEFORM_FIELD_NAME);
+        validateTsvRow(tsvLineList.get(1), "This is a string.", "Example (not) long string",
+                "Potentially unbounded string", "42", String.valueOf(submitTimeMillis), "+0900", "true", "false",
+                "true", "false", DUMMY_FILEHANDLE_ID);
 
         // validate metrics
         Multiset<String> counterMap = task.getMetrics().getCounterMap();

--- a/src/test/java/org/sagebionetworks/bridge/exporter/synapse/SynapseHelperSerializeTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/synapse/SynapseHelperSerializeTest.java
@@ -184,6 +184,26 @@ public class SynapseHelperSerializeTest {
         assertEquals(retVal, "link");
     }
 
+    // branch coverage
+    @Test(dataProvider = "stringTypeProvider")
+    public void stringUnboundedTrue(UploadFieldType stringType) throws Exception {
+        UploadFieldDefinition fieldDef = new UploadFieldDefinition.Builder().withName(TEST_FIELD_NAME)
+                .withType(stringType).withUnboundedText(true).build();
+        String retVal = new SynapseHelper().serializeToSynapseType(MOCK_TEMP_DIR, TEST_PROJECT_ID, TEST_RECORD_ID,
+                fieldDef, new TextNode("unbounded text not really"));
+        assertEquals(retVal, "unbounded text not really");
+    }
+
+    // branch coverage
+    @Test(dataProvider = "stringTypeProvider")
+    public void stringUnboundedFalse(UploadFieldType stringType) throws Exception {
+        UploadFieldDefinition fieldDef = new UploadFieldDefinition.Builder().withName(TEST_FIELD_NAME)
+                .withType(stringType).withUnboundedText(false).build();
+        String retVal = new SynapseHelper().serializeToSynapseType(MOCK_TEMP_DIR, TEST_PROJECT_ID, TEST_RECORD_ID,
+                fieldDef, new TextNode("not really unbounded text"));
+        assertEquals(retVal, "not really unbounded text");
+    }
+
     @Test
     public void time() throws Exception {
         String retVal = new SynapseHelper().serializeToSynapseType(MOCK_TEMP_DIR, TEST_PROJECT_ID, TEST_RECORD_ID,

--- a/src/test/java/org/sagebionetworks/bridge/exporter/util/BridgeExporterUtilTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/util/BridgeExporterUtilTest.java
@@ -151,6 +151,13 @@ public class BridgeExporterUtilTest {
         assertEquals(out, "1234");
     }
 
+    // branch coverage
+    @Test
+    public void sanitizeStringNullMaxLength() {
+        String out = BridgeExporterUtil.sanitizeString("stuff", null, "dummy-record");
+        assertEquals(out, "stuff");
+    }
+
     @Test
     public void shouldConvertFreeformTextToAttachment() {
         // This is a hack, but we still need to test it.


### PR DESCRIPTION
Add support for unbounded text, text that should always use LargeText (blob) regardless of maxLength. Unbounded text is also not clipped to fit within the maxLength.

Testing done:
- updated unit tests for coverage
- manually tested a schema and an upload with short text, long text, and unbounded text
