### PR TITLE
upload auto-complete: add null/empty check for record list

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/exporter/notification/S3EventNotificationCallback.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/notification/S3EventNotificationCallback.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.bridge.exporter.notification;
 
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import com.amazonaws.services.s3.event.S3EventNotification;
@@ -56,6 +57,12 @@ public class S3EventNotificationCallback implements PollSqsCallback {
     @Override
     public void callback(String messageBody) throws Exception {
         S3EventNotification notification = OBJECT_MAPPER.readValue(messageBody, S3EventNotification.class);
+        List<S3EventNotification.S3EventNotificationRecord> recordList = notification.getRecords();
+        if (recordList == null || recordList.isEmpty()) {
+            // Notification w/o record list is not actionable. Log a warning and squelch.
+            LOG.warn("S3 notification without record list: " + messageBody);
+            return;
+        }
 
         callback(notification);
     }

--- a/src/test/java/org/sagebionetworks/bridge/exporter/notification/S3EventNotificationCallbackTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/notification/S3EventNotificationCallbackTest.java
@@ -1,8 +1,10 @@
 package org.sagebionetworks.bridge.exporter.notification;
 
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -57,6 +59,18 @@ public class S3EventNotificationCallbackTest {
         callback.callback(UPLOAD_COMPLETE_MESSAGE);
 
         verify(mockWorkerClient, times(1)).completeUpload(UPLOAD_ID);
+    }
+
+    @Test
+    public void testCallback_NullList() throws Exception {
+        callback.callback("{}");
+        verify(mockWorkerClient, never()).completeUpload(anyString());
+    }
+
+    @Test
+    public void testCallback_EmptyList() throws Exception {
+        callback.callback("{\"Records\":[]}");
+        verify(mockWorkerClient, never()).completeUpload(anyString());
     }
 
     @Test


### PR DESCRIPTION
It looks like the S3 notifications will occasionally send test events in the form of
{
  "Service": "Amazon S3",
  "Event": "s3:TestEvent",
  "Time": "2016-07-19T16:32:36.889Z",
  "Bucket": "org-sagebridge-upload-local",
  "RequestId": "E7C6D565B7ECEE5D",
  "HostId": "F4jlwRZcT6vUxsVyoyPzi5nYzEw2+Jji1NL1UeCJylvmVvGBCP6GPjIIKHk6Bwuz"
}

And this causes a NullPointerException in our code. Which results in infinitely re-cycled requests and error spam. (It's not entirely clear what triggers S3 to send these events.)

This change adds a null check to squelch null and empty record lists.

Testing done:
- mvn verify (unit tests, findbugs, jacoco test coverage)
- manually send the test event via SQS
- manually test upload auto-complete normal case
