### PR TITLE
pull in connection leak fixes for bridge-base and SynapseJavaClient

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <dependency>
             <groupId>org.sagebionetworks</groupId>
             <artifactId>bridge-base</artifactId>
-            <version>2.2</version>
+            <version>2.6</version>
         </dependency>
         <dependency>
             <groupId>org.sagebionetworks.bridge</groupId>
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>org.sagebionetworks</groupId>
             <artifactId>synapseJavaClient</artifactId>
-            <version>131.0</version>
+            <version>145.0</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
We have a semi-regular problem with connection timeouts causing BridgeEX to fail catastrophically. This pulls in changes for bridge-base and SynapseJavaClient which should hopefully fix some, if not all, connection issues.

Testing done:
- mvn verify (unit tests, findbugs, jacoco test coverage)
- manual tested a redrive scenario, which pulls a list of record IDs from an S3 file (the main way this hits that bridge-base code path

This is dependent on https://github.com/Sage-Bionetworks/bridge-base/pull/25
