### PR TITLE
fix Health Data Handler holding onto schemas forever

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/exporter/handler/AppVersionExportHandler.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/handler/AppVersionExportHandler.java
@@ -49,7 +49,7 @@ public class AppVersionExportHandler extends SynapseExportHandler {
     }
 
     @Override
-    protected List<ColumnModel> getSynapseTableColumnList() {
+    protected List<ColumnModel> getSynapseTableColumnList(ExportTask task) {
         return APPVERSION_COLUMN_LIST;
     }
 

--- a/src/main/java/org/sagebionetworks/bridge/exporter/handler/SynapseExportHandler.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/handler/SynapseExportHandler.java
@@ -26,6 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.sagebionetworks.bridge.exporter.exceptions.BridgeExporterException;
+import org.sagebionetworks.bridge.exporter.exceptions.SchemaNotFoundException;
 import org.sagebionetworks.bridge.exporter.metrics.Metrics;
 import org.sagebionetworks.bridge.exporter.util.BridgeExporterUtil;
 import org.sagebionetworks.bridge.exporter.worker.ExportSubtask;
@@ -125,7 +126,8 @@ public abstract class SynapseExportHandler extends ExportHandler {
             // write to TSV
             tsvInfo.writeRow(rowValueMap);
             metrics.incrementCounter(tableKey + ".lineCount");
-        } catch (BridgeExporterException | IOException | RuntimeException | SynapseException ex) {
+        } catch (BridgeExporterException | IOException | RuntimeException | SchemaNotFoundException |
+                SynapseException ex) {
             metrics.incrementCounter(tableKey + ".errorCount");
             LOG.error("Error processing record " + recordId + " for table " + tableKey + ": " + ex.getMessage(), ex);
         }
@@ -152,7 +154,7 @@ public abstract class SynapseExportHandler extends ExportHandler {
 
             // create TSV info
             tsvInfo = new TsvInfo(columnNameList, tsvFile, tsvWriter);
-        } catch (BridgeExporterException | FileNotFoundException | SynapseException ex) {
+        } catch (BridgeExporterException | FileNotFoundException | SchemaNotFoundException | SynapseException ex) {
             LOG.error("Error initializing TSV for table " + getDdbTableKeyValue() + ": " + ex.getMessage(), ex);
             tsvInfo = TsvInfo.INIT_ERROR_TSV_INFO;
         }
@@ -163,11 +165,12 @@ public abstract class SynapseExportHandler extends ExportHandler {
 
     // Gets the column name list from Synapse. If the Synapse table doesn't exist, this will create it. This is called
     // when initializing the TSV for a task.
-    private List<String> getColumnNameList(ExportTask task) throws BridgeExporterException, SynapseException {
+    private List<String> getColumnNameList(ExportTask task) throws BridgeExporterException, SchemaNotFoundException,
+            SynapseException {
         // Construct column definition list. Merge COMMON_COLUMN_LIST with getSynapseTableColumnList.
         List<ColumnModel> columnDefList = new ArrayList<>();
         columnDefList.addAll(COMMON_COLUMN_LIST);
-        columnDefList.addAll(getSynapseTableColumnList());
+        columnDefList.addAll(getSynapseTableColumnList(task));
 
         // Create or update table if necessary.
         String synapseTableId = getManager().getSynapseTableIdFromDdb(task, getDdbTableName(), getDdbTableKeyName(),
@@ -375,7 +378,7 @@ public abstract class SynapseExportHandler extends ExportHandler {
      * List of Synapse table column model objects, to be used to create both the column models and the Synapse table.
      * This excludes columns common to all Bridge tables defined in COMMON_COLUMN_LIST.
      */
-    protected abstract List<ColumnModel> getSynapseTableColumnList();
+    protected abstract List<ColumnModel> getSynapseTableColumnList(ExportTask task) throws SchemaNotFoundException;
 
     /** Get the TSV saved in the task for this handler. */
     protected abstract TsvInfo getTsvInfoForTask(ExportTask task);
@@ -384,5 +387,6 @@ public abstract class SynapseExportHandler extends ExportHandler {
     protected abstract void setTsvInfoForTask(ExportTask task, TsvInfo tsvInfo);
 
     /** Creates a row values for a single row from the given export task. */
-    protected abstract Map<String, String> getTsvRowValueMap(ExportSubtask subtask) throws IOException, SynapseException;
+    protected abstract Map<String, String> getTsvRowValueMap(ExportSubtask subtask) throws IOException,
+            SchemaNotFoundException, SynapseException;
 }

--- a/src/main/java/org/sagebionetworks/bridge/exporter/worker/ExportWorkerManager.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/worker/ExportWorkerManager.java
@@ -42,7 +42,6 @@ import org.sagebionetworks.bridge.file.FileHelper;
 import org.sagebionetworks.bridge.json.DefaultObjectMapper;
 import org.sagebionetworks.bridge.schema.UploadSchemaKey;
 import org.sagebionetworks.bridge.exporter.synapse.SynapseHelper;
-import org.sagebionetworks.bridge.sdk.models.upload.UploadSchema;
 
 /**
  * This class manages export handlers and workers. This includes holding the config and helper objects that the
@@ -414,14 +413,15 @@ public class ExportWorkerManager {
     // Factory method for creating a new health data handler. This exists and is package-scoped to enable unit tests.
     HealthDataExportHandler createHealthDataHandler(Metrics metrics, UploadSchemaKey schemaKey)
             throws IOException, SchemaNotFoundException {
+        // Validate schema exists. This throws if schema doesn't exist. It's also cached, so we don't need to worry
+        // about excessive calls to Bridge.
+        bridgeHelper.getSchema(metrics, schemaKey);
+
+        // create and return handler
         HealthDataExportHandler handler = new HealthDataExportHandler();
         handler.setManager(this);
+        handler.setSchemaKey(schemaKey);
         handler.setStudyId(schemaKey.getStudyId());
-
-        // set schema
-        UploadSchema schema = bridgeHelper.getSchema(metrics, schemaKey);
-        handler.setSchema(schema);
-
         return handler;
     }
 

--- a/src/test/java/org/sagebionetworks/bridge/exporter/handler/SynapseExportHandlerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/handler/SynapseExportHandlerTest.java
@@ -32,11 +32,13 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.config.Config;
+import org.sagebionetworks.bridge.exporter.helper.BridgeHelper;
 import org.sagebionetworks.bridge.exporter.helper.BridgeHelperTest;
 import org.sagebionetworks.bridge.exporter.helper.ExportHelper;
 import org.sagebionetworks.bridge.exporter.metrics.Metrics;
 import org.sagebionetworks.bridge.exporter.request.BridgeExporterRequest;
 import org.sagebionetworks.bridge.exporter.synapse.SynapseHelper;
+import org.sagebionetworks.bridge.exporter.util.BridgeExporterUtil;
 import org.sagebionetworks.bridge.exporter.util.TestUtil;
 import org.sagebionetworks.bridge.exporter.worker.ExportSubtask;
 import org.sagebionetworks.bridge.exporter.worker.ExportTask;
@@ -64,7 +66,7 @@ public class SynapseExportHandlerTest {
     private static final String DUMMY_DATA_GROUPS_FLATTENED = "bar,baz,foo";
     private static final String DUMMY_HEALTH_CODE = "dummy-health-code";
     private static final String DUMMY_RECORD_ID = "dummy-record-id";
-    private static final Item DUMMY_RECORD = new Item().withLong("createdOn", DUMMY_CREATED_ON)
+    public static final Item DUMMY_RECORD = new Item().withLong("createdOn", DUMMY_CREATED_ON)
             .withString("healthCode", DUMMY_HEALTH_CODE).withString("id", DUMMY_RECORD_ID)
             .withString("metadata", DUMMY_METADATA_JSON_TEXT).withStringSet("userDataGroups", DUMMY_DATA_GROUPS)
             .withString("userExternalId", "unsanitized\t\texternal\t\tid");
@@ -107,8 +109,17 @@ public class SynapseExportHandlerTest {
     }
 
     private void setup(SynapseExportHandler handler) throws Exception {
+        setupWithSchema(handler, null, null);
+    }
+
+    private void setupWithSchema(SynapseExportHandler handler, UploadSchemaKey schemaKey, UploadSchema schema)
+    throws Exception {
         // This needs to be done first, because lots of stuff reference this, even while we're setting up mocks.
         handler.setStudyId(TEST_STUDY_ID);
+
+        // mock BridgeHelper
+        BridgeHelper mockBridgeHelper = mock(BridgeHelper.class);
+        when(mockBridgeHelper.getSchema(any(), eq(schemaKey))).thenReturn(schema);
 
         // mock config
         Config mockConfig = mock(Config.class);
@@ -121,15 +132,13 @@ public class SynapseExportHandlerTest {
         mockFileHelper = new InMemoryFileHelper();
         File tmpDir = mockFileHelper.createTempDir();
 
-        // mock Synapse helper
-        List<ColumnModel> columnModelList = new ArrayList<>();
-        columnModelList.addAll(SynapseExportHandler.COMMON_COLUMN_LIST);
-        columnModelList.addAll(handler.getSynapseTableColumnList());
+        // Mock Synapse Helper - We'll fill in the behavior later, because due to the way this test is constructed, we
+        // need to set up the Manager before we can properly mock the Synapse Helper.
         mockSynapseHelper = mock(SynapseHelper.class);
-        when(mockSynapseHelper.getColumnModelsForTableWithRetry(TEST_SYNAPSE_TABLE_ID)).thenReturn(columnModelList);
 
         // setup manager - This is mostly used to get helper objects.
         ExportWorkerManager manager = spy(new ExportWorkerManager());
+        manager.setBridgeHelper(mockBridgeHelper);
         manager.setConfig(mockConfig);
         manager.setFileHelper(mockFileHelper);
         manager.setSynapseHelper(mockSynapseHelper);
@@ -138,6 +147,12 @@ public class SynapseExportHandlerTest {
         // set up task
         task = new ExportTask.Builder().withExporterDate(DUMMY_REQUEST_DATE).withMetrics(new Metrics())
                 .withRequest(DUMMY_REQUEST).withTmpDir(tmpDir).build();
+
+        // mock Synapse helper
+        List<ColumnModel> columnModelList = new ArrayList<>();
+        columnModelList.addAll(SynapseExportHandler.COMMON_COLUMN_LIST);
+        columnModelList.addAll(handler.getSynapseTableColumnList(task));
+        when(mockSynapseHelper.getColumnModelsForTableWithRetry(TEST_SYNAPSE_TABLE_ID)).thenReturn(columnModelList);
 
         // spy getSynapseProjectId and getDataAccessTeam
         // These calls through to a bunch of stuff (which we test in ExportWorkerManagerTest), so to simplify our test,
@@ -306,12 +321,13 @@ public class SynapseExportHandlerTest {
                         new UploadFieldDefinition.Builder().withName(FREEFORM_FIELD_NAME)
                                 .withType(UploadFieldType.STRING).build())
                 .build();
+        UploadSchemaKey testSchemaKey = BridgeExporterUtil.getSchemaKeyFromSchema(testSchema);
 
         // Set up handler and test. setSchema() needs to be called before setup, since a lot of the stuff in the
         // handler depends on it, even while we're mocking stuff.
         HealthDataExportHandler handler = new HealthDataExportHandler();
-        handler.setSchema(testSchema);
-        setup(handler);
+        handler.setSchemaKey(testSchemaKey);
+        setupWithSchema(handler, testSchemaKey, testSchema);
         mockSynapseHelperUploadTsv(1);
 
         // mock export helper

--- a/src/test/java/org/sagebionetworks/bridge/exporter/handler/SynapseExportHandlerUpdateTableTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/handler/SynapseExportHandlerUpdateTableTest.java
@@ -73,6 +73,11 @@ public class SynapseExportHandlerUpdateTableTest {
         InMemoryFileHelper mockFileHelper = new InMemoryFileHelper();
         File tmpDir = mockFileHelper.createTempDir();
 
+        // set up task
+        task = new ExportTask.Builder().withExporterDate(SynapseExportHandlerTest.DUMMY_REQUEST_DATE)
+                .withMetrics(new Metrics()).withRequest(SynapseExportHandlerTest.DUMMY_REQUEST).withTmpDir(tmpDir)
+                .build();
+
         // mock Synapse helper
         mockSynapseHelper = mock(SynapseHelper.class);
 
@@ -83,7 +88,7 @@ public class SynapseExportHandlerUpdateTableTest {
         // mock create column model list - We only care about the names and IDs for the created columns.
         expectedColDefList = new ArrayList<>();
         expectedColDefList.addAll(SynapseExportHandler.COMMON_COLUMN_LIST);
-        expectedColDefList.addAll(handler.getSynapseTableColumnList());
+        expectedColDefList.addAll(handler.getSynapseTableColumnList(task));
 
         List<ColumnModel> createdColumnList = new ArrayList<>();
         expectedColIdList = new ArrayList<>();
@@ -123,11 +128,6 @@ public class SynapseExportHandlerUpdateTableTest {
         manager.setSynapseHelper(mockSynapseHelper);
         handler.setManager(manager);
 
-        // set up task
-        task = new ExportTask.Builder().withExporterDate(SynapseExportHandlerTest.DUMMY_REQUEST_DATE)
-                .withMetrics(new Metrics()).withRequest(SynapseExportHandlerTest.DUMMY_REQUEST).withTmpDir(tmpDir)
-                .build();
-
         // spy getSynapseProjectId and getDataAccessTeam
         // These calls through to a bunch of stuff (which we test in ExportWorkerManagerTest), so to simplify our test,
         // we just use a spy here.
@@ -146,7 +146,7 @@ public class SynapseExportHandlerUpdateTableTest {
     // Subclass TestSynapseHandler and add a few more fields.
     private static class UpdateTestSynapseHandler extends TestSynapseHandler {
         @Override
-        protected List<ColumnModel> getSynapseTableColumnList() {
+        protected List<ColumnModel> getSynapseTableColumnList(ExportTask task) {
             return ImmutableList.of(makeColumn("modify-this"), makeColumn("add-this"), makeColumn("swap-this-A"),
                     makeColumn("swap-this-B"));
         }

--- a/src/test/java/org/sagebionetworks/bridge/exporter/handler/TestSynapseHandler.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/handler/TestSynapseHandler.java
@@ -34,7 +34,7 @@ public class TestSynapseHandler extends SynapseExportHandler {
     }
 
     @Override
-    protected List<ColumnModel> getSynapseTableColumnList() {
+    protected List<ColumnModel> getSynapseTableColumnList(ExportTask task) {
         List<ColumnModel> columnList = new ArrayList<>();
 
         ColumnModel fooColumn = new ColumnModel();

--- a/src/test/java/org/sagebionetworks/bridge/exporter/helper/BridgeHelperTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/helper/BridgeHelperTest.java
@@ -11,6 +11,8 @@ import static org.testng.Assert.fail;
 import java.util.SortedSet;
 
 import com.google.common.collect.SortedSetMultimap;
+import org.sagebionetworks.repo.model.table.ColumnModel;
+import org.sagebionetworks.repo.model.table.ColumnType;
 import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.exporter.exceptions.SchemaNotFoundException;
@@ -23,11 +25,20 @@ import org.sagebionetworks.bridge.sdk.models.upload.UploadSchema;
 import org.sagebionetworks.bridge.sdk.models.upload.UploadSchemaType;
 
 public class BridgeHelperTest {
-    public static final UploadFieldDefinition TEST_FIELD_DEF = new UploadFieldDefinition.Builder().withName("my-field")
-            .withType(UploadFieldType.STRING).build();
     public static final String TEST_SCHEMA_ID = "my-schema";
     public static final int TEST_SCHEMA_REV = 2;
     public static final String TEST_STUDY_ID = "test-study";
+
+    public static final String TEST_FIELD_NAME = "my-field";
+    public static final UploadFieldDefinition TEST_FIELD_DEF = new UploadFieldDefinition.Builder()
+            .withName(TEST_FIELD_NAME).withType(UploadFieldType.STRING).withUnboundedText(true).build();
+
+    public static final ColumnModel TEST_SYNAPSE_COLUMN;
+    static {
+        TEST_SYNAPSE_COLUMN = new ColumnModel();
+        TEST_SYNAPSE_COLUMN.setName(TEST_FIELD_NAME);
+        TEST_SYNAPSE_COLUMN.setColumnType(ColumnType.LARGETEXT);
+    }
 
     public static final UploadSchema TEST_SCHEMA = simpleSchemaBuilder().withFieldDefinitions(TEST_FIELD_DEF).build();
     public static final UploadSchemaKey TEST_SCHEMA_KEY = new UploadSchemaKey.Builder().withStudyId(TEST_STUDY_ID)

--- a/src/test/java/org/sagebionetworks/bridge/exporter/worker/ExportWorkerManagerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/worker/ExportWorkerManagerTest.java
@@ -333,7 +333,7 @@ public class ExportWorkerManagerTest {
         assertEquals(appVersionHandler.getStudyId(), TEST_STUDY_ID);
 
         assertSame(healthDataHandler.getManager(), manager);
-        assertSame(healthDataHandler.getSchema(), BridgeHelperTest.TEST_SCHEMA);
+        assertEquals(healthDataHandler.getSchemaKey(), testSchemaKey);
         assertEquals(healthDataHandler.getStudyId(), TEST_STUDY_ID);
 
         // verify task queue


### PR DESCRIPTION
See https://sagebionetworks.jira.com/browse/BRIDGE-1454

Health Data Handler stores a copy of the schema and has no mechanism to update it. This effectively caches schemas forever. This is bad, because it prevents mutable schemas from being mutable.

The fix is to have Health Data Handler store a reference to the schema key, and then call Bridge for the schema (which is cached for 5 minutes via BridgeHelper).

Testing done:
- mvn verify (unit tests, findbugs, jacoco test coverage)
- manually tested running the exporter, updating the schema, and running the exporter again to verify schema changes were picked up
