### PR TITLE
Fix redrive bug; improve Bridge Server sessions

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/exporter/worker/ExportWorkerManager.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/worker/ExportWorkerManager.java
@@ -13,6 +13,7 @@ import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Resource;
 
+import com.amazonaws.AmazonClientException;
 import com.amazonaws.services.dynamodbv2.document.DynamoDB;
 import com.amazonaws.services.dynamodbv2.document.Item;
 import com.amazonaws.services.dynamodbv2.document.Table;
@@ -541,7 +542,7 @@ public class ExportWorkerManager {
 
                 // send request to SQS
                 sqsHelper.sendMessageAsJson(sqsQueueUrl, redriveRequest, REDRIVE_DELAY_SECONDS);
-            } catch (IOException ex) {
+            } catch (AmazonClientException | IOException ex) {
                 // log error, but move on
                 LOG.error("Error redriving records: " + ex.getMessage(), ex);
             }

--- a/src/main/java/org/sagebionetworks/bridge/exporter/worker/ExportWorkerManager.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/worker/ExportWorkerManager.java
@@ -581,7 +581,7 @@ public class ExportWorkerManager {
 
             try {
                 sqsHelper.sendMessageAsJson(sqsQueueUrl, redriveRequest, REDRIVE_DELAY_SECONDS);
-            } catch (JsonProcessingException ex) {
+            } catch (AmazonClientException | JsonProcessingException ex) {
                 // log error, but move on
                 LOG.error("Error redriving tables: " + ex.getMessage(), ex);
             }

--- a/src/main/java/org/sagebionetworks/bridge/exporter/worker/ExportWorkerManager.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/worker/ExportWorkerManager.java
@@ -73,7 +73,8 @@ public class ExportWorkerManager {
 
     // We need to delay our redrives. Otherwise, if we have a deterministic error, this may cause the Exporter to spin
     // as fast as possible retrying the request.
-    static final int REDRIVE_DELAY_SECONDS = 3600;
+    // NOTE: This maxes out at 900 seconds (15 min) before SQS throws an error.
+    static final int REDRIVE_DELAY_SECONDS = 900;
 
     // CONFIG
 

--- a/src/test/java/org/sagebionetworks/bridge/exporter/helper/BridgeHelperTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/helper/BridgeHelperTest.java
@@ -1,8 +1,12 @@
 package org.sagebionetworks.bridge.exporter.helper;
 
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -18,12 +22,15 @@ import org.testng.annotations.Test;
 import org.sagebionetworks.bridge.exporter.exceptions.SchemaNotFoundException;
 import org.sagebionetworks.bridge.exporter.metrics.Metrics;
 import org.sagebionetworks.bridge.schema.UploadSchemaKey;
+import org.sagebionetworks.bridge.sdk.Session;
 import org.sagebionetworks.bridge.sdk.UploadSchemaClient;
+import org.sagebionetworks.bridge.sdk.exceptions.NotAuthenticatedException;
 import org.sagebionetworks.bridge.sdk.models.upload.UploadFieldDefinition;
 import org.sagebionetworks.bridge.sdk.models.upload.UploadFieldType;
 import org.sagebionetworks.bridge.sdk.models.upload.UploadSchema;
 import org.sagebionetworks.bridge.sdk.models.upload.UploadSchemaType;
 
+@SuppressWarnings("unchecked")
 public class BridgeHelperTest {
     public static final String TEST_SCHEMA_ID = "my-schema";
     public static final int TEST_SCHEMA_REV = 2;
@@ -85,9 +92,65 @@ public class BridgeHelperTest {
         UploadSchemaClient mockSchemaClient = mock(UploadSchemaClient.class);
         when(mockSchemaClient.getSchema(TEST_STUDY_ID, TEST_SCHEMA_ID, TEST_SCHEMA_REV)).thenReturn(schema);
 
-        // Spy bridge helper, because getSchemaClient() statically calls ClientProvider.signIn()
+        // mock session, which returns the schema client
+        Session mockSession = mock(Session.class);
+        when(mockSession.getUploadSchemaClient()).thenReturn(mockSchemaClient);
+
+        // Spy bridge helper, because signIn() statically calls ClientProvider.signIn()
         BridgeHelper bridgeHelper = spy(new BridgeHelper());
-        doReturn(mockSchemaClient).when(bridgeHelper).getSchemaClient();
+        doReturn(mockSession).when(bridgeHelper).signIn();
         return bridgeHelper;
+    }
+
+    @Test
+    public void testSessionHelper() throws Exception {
+        // 3 test cases:
+        // 1. first request initializes session
+        // 2. second request re-uses same session
+        // 3. third request gets 401'ed, refreshes session
+        //
+        // This necessitates 4 calls to our test server call (we'll use getSchema):
+        // 1. Initial call succeeds.
+        // 2. Second call also succeeds.
+        // 3. Third call throws 401.
+        // 4. Fourth call succeeds, to complete our call pattern.
+
+        // Create 2 mock schema clients.
+        // First schema client succeeds twice, then 401s.
+        // Second schema client succeeds.
+        UploadSchemaClient mockSchemaClient1 = mock(UploadSchemaClient.class);
+        when(mockSchemaClient1.getSchema(eq(TEST_STUDY_ID), eq(TEST_SCHEMA_ID), anyInt())).thenReturn(TEST_SCHEMA)
+                .thenReturn(TEST_SCHEMA).thenThrow(NotAuthenticatedException.class);
+
+        UploadSchemaClient mockSchemaClient2 = mock(UploadSchemaClient.class);
+        when(mockSchemaClient2.getSchema(eq(TEST_STUDY_ID), eq(TEST_SCHEMA_ID), anyInt())).thenReturn(TEST_SCHEMA);
+
+        // Create 2 mock sessions. Each mock session simply returns its corresponing schema client.
+        Session mockSession1 = mock(Session.class);
+        when(mockSession1.getUploadSchemaClient()).thenReturn(mockSchemaClient1);
+
+        Session mockSession2 = mock(Session.class);
+        when(mockSession2.getUploadSchemaClient()).thenReturn(mockSchemaClient2);
+
+        // Spy BridgeHelper.signIn(), which returns these sessions.
+        BridgeHelper bridgeHelper = spy(new BridgeHelper());
+        doReturn(mockSession1).doReturn(mockSession2).when(bridgeHelper).signIn();
+
+        // Dummy metrics for test.
+        Metrics metrics = new Metrics();
+
+        // Call BridgeHelper.getSchema() 3 times. Each call will look identical, except pass in a different rev to
+        // bypass the cache.
+        for (int i = 1; i <= 3; i++) {
+            UploadSchemaKey schemaKey = new UploadSchemaKey.Builder().withStudyId(TEST_STUDY_ID)
+                    .withSchemaId(TEST_SCHEMA_ID).withRevision(i).build();
+            UploadSchema retval = bridgeHelper.getSchema(metrics, schemaKey);
+            assertEquals(retval, TEST_SCHEMA);
+        }
+
+        // Validate behind the scenes. We made 3 calls to mockSchemaClient1 and 1 call to mockSchemaClient2. This
+        // ensures we're properly throwing and catching 401s and refreshing sessions.
+        verify(mockSchemaClient1, times(3)).getSchema(eq(TEST_STUDY_ID), eq(TEST_SCHEMA_ID), anyInt());
+        verify(mockSchemaClient2, times(1)).getSchema(eq(TEST_STUDY_ID), eq(TEST_SCHEMA_ID), anyInt());
     }
 }


### PR DESCRIPTION
Three fixes:
1. Fix session handling in BridgeHelper. This new code caches sessions "forever", but has handling to detect when sessions expire and refresh the session.
2. Added AmazonClientException to the catch block when redrives. This allows us to fail gracefully if the S3 upload fails or the SQS send fails.
3. Max delay for SQS is 900 seconds (15 min).

Testing done:
- mvn verify (unit tests, findbugs, jacoco test coverage)
- manual tests

Manual tests:
- normal case
- manually expire session, verified BridgeEX refreshes sessions in logs
- inject error, block upload to S3 (with permissions), verify BridgeEX fails gracefully
- inject error, use test delay of 30 seconds, verify BridgeEX redrives successfully
- inject error, use real delay of 900 seconds, verify the message is successfully sent to SQS
