### PR TITLE
improved session handling for Upload Auto-Complete

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/exporter/helper/BridgeHelper.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/helper/BridgeHelper.java
@@ -34,6 +34,21 @@ public class BridgeHelper {
     }
 
     /**
+     * Signals Bridge Server that the upload is completed and to begin processing the upload. Used by Upload
+     * Auto-Complete.
+     *
+     * @param uploadId
+     *         upload to mark completed and begin processing
+     */
+    public void completeUpload(String uploadId) {
+        sessionHelper(() -> {
+            session.getWorkerClient().completeUpload(uploadId);
+            // Needs return null because session helper expects a return value.
+            return null;
+        });
+    }
+
+    /**
      * Returns the schema for the given key.
      *
      * @param metrics


### PR DESCRIPTION
Currently, Upload Auto-Complete caches the Bridge session for 5 minutes. This means, when Bridge session expires, for up to 5 minutes, we're unable to auto-complete uploads.

BridgeHelper in the Bridge-EX project already has better session management, which catches the 401, signs in, and retries the call. This change updates Upload Auto-Complete to use BridgeHelper instead of managing sessions directly. It also updates error handling to propagate 401s and 403s, which indicate a problem with the client rather than the request.

Testing done:
- manual tests to verify we automatically refresh the session
- rigged up local Bridge server to verify new error handling logic
- updated unit tests
- mvn verify (unit tests, jacoco test coverage, findbugs)

See https://sagebionetworks.jira.com/browse/BRIDGE-1485
