### PR TITLE
switch from SynapseClient.createFileHandle() to SynapseClient.multipartUpload()

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>org.sagebionetworks</groupId>
             <artifactId>synapseJavaClient</artifactId>
-            <version>145.0</version>
+            <version>157.0</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/java/org/sagebionetworks/bridge/exporter/synapse/SynapseHelper.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/synapse/SynapseHelper.java
@@ -21,6 +21,7 @@ import org.sagebionetworks.repo.model.ACCESS_TYPE;
 import org.sagebionetworks.repo.model.AccessControlList;
 import org.sagebionetworks.repo.model.ResourceAccess;
 import org.sagebionetworks.repo.model.file.FileHandle;
+import org.sagebionetworks.repo.model.file.UploadDestination;
 import org.sagebionetworks.repo.model.status.StackStatus;
 import org.sagebionetworks.repo.model.status.StatusEnum;
 import org.sagebionetworks.repo.model.table.AppendableRowSet;
@@ -511,7 +512,8 @@ public class SynapseHelper {
             types = { AmazonClientException.class, SynapseException.class }, randomize = false)
     public FileHandle createFileHandleWithRetry(File file, String contentType, String projectId) throws IOException,
             SynapseException {
-        return synapseClient.createFileHandle(file, contentType, projectId);
+        UploadDestination uploadDestination = synapseClient.getDefaultUploadDestination(projectId);
+        return synapseClient.multipartUpload(file, uploadDestination.getStorageLocationId(), null, null);
     }
 
     /**

--- a/src/test/java/org/sagebionetworks/bridge/exporter/synapse/SynapseHelperTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/synapse/SynapseHelperTest.java
@@ -24,6 +24,8 @@ import org.sagebionetworks.client.exceptions.SynapseResultNotReadyException;
 import org.sagebionetworks.repo.model.AccessControlList;
 import org.sagebionetworks.repo.model.ResourceAccess;
 import org.sagebionetworks.repo.model.file.FileHandle;
+import org.sagebionetworks.repo.model.file.S3FileHandle;
+import org.sagebionetworks.repo.model.file.UploadDestination;
 import org.sagebionetworks.repo.model.status.StackStatus;
 import org.sagebionetworks.repo.model.status.StatusEnum;
 import org.sagebionetworks.repo.model.table.ColumnModel;
@@ -121,10 +123,14 @@ public class SynapseHelperTest {
     public void createFileHandle() throws Exception {
         // mock Synapse Client
         SynapseClient mockSynapseClient = mock(SynapseClient.class);
+
+        UploadDestination mockUploadDestination = mock(UploadDestination.class);
+        when(mockUploadDestination.getStorageLocationId()).thenReturn(1234L);
+        when(mockSynapseClient.getDefaultUploadDestination("project-id")).thenReturn(mockUploadDestination);
+
         File mockFile = mock(File.class);
-        FileHandle mockFileHandle = mock(FileHandle.class);
-        when(mockSynapseClient.createFileHandle(mockFile, "application/mock", "project-id"))
-                .thenReturn(mockFileHandle);
+        S3FileHandle mockFileHandle = mock(S3FileHandle.class);
+        when(mockSynapseClient.multipartUpload(mockFile, 1234L, null, null)).thenReturn(mockFileHandle);
 
         SynapseHelper synapseHelper = new SynapseHelper();
         synapseHelper.setSynapseClient(mockSynapseClient);


### PR DESCRIPTION
BridgeEX has frequent connection issues uploading file handles to Synapse.

We determined that this is because BridgeEX uses the old deprecated SynapseClient.createFileHandle(), which may have connection leak issues. We switched to the new SynapseClient.multipartUpload(), which is much more robust.

Testing done:
- mvn verify (unit tests, findbugs, jacoco test coverage)
- manual tests, include tests with an attachment (file handle)
