### PR TITLE
migrate to new Bridge REST Client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,11 @@
             <version>${jackson.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.8.0</version>
+        </dependency>
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>19.0</version>
@@ -76,8 +81,8 @@
         </dependency>
         <dependency>
             <groupId>org.sagebionetworks.bridge</groupId>
-            <artifactId>java-sdk</artifactId>
-            <version>0.11.1</version>
+            <artifactId>rest-client</artifactId>
+            <version>0.12.16</version>
         </dependency>
         <dependency>
             <groupId>org.sagebionetworks</groupId>

--- a/src/main/java/org/sagebionetworks/bridge/exporter/config/SpringConfig.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/config/SpringConfig.java
@@ -27,10 +27,10 @@ import org.sagebionetworks.bridge.exporter.request.BridgeExporterSqsCallback;
 import org.sagebionetworks.bridge.exporter.util.BridgeExporterUtil;
 import org.sagebionetworks.bridge.file.FileHelper;
 import org.sagebionetworks.bridge.heartbeat.HeartbeatLogger;
+import org.sagebionetworks.bridge.rest.ClientManager;
+import org.sagebionetworks.bridge.rest.model.ClientInfo;
+import org.sagebionetworks.bridge.rest.model.SignIn;
 import org.sagebionetworks.bridge.s3.S3Helper;
-import org.sagebionetworks.bridge.sdk.ClientInfo;
-import org.sagebionetworks.bridge.sdk.ClientProvider;
-import org.sagebionetworks.bridge.sdk.models.accounts.SignInCredentials;
 import org.sagebionetworks.bridge.sqs.PollSqsWorker;
 import org.sagebionetworks.bridge.sqs.SqsHelper;
 import org.sagebionetworks.client.SynapseAdminClientImpl;
@@ -46,13 +46,6 @@ public class SpringConfig {
     private static final String CONFIG_FILE = "BridgeExporter.conf";
     private static final String DEFAULT_CONFIG_FILE = CONFIG_FILE;
     private static final String USER_CONFIG_FILE = System.getProperty("user.home") + "/" + CONFIG_FILE;
-
-    // ClientProvider needs to be statically configured.
-    static {
-        // set client info
-        ClientInfo clientInfo = new ClientInfo.Builder().withAppName("BridgeEX").withAppVersion(2).build();
-        ClientProvider.setClientInfo(clientInfo);
-    }
 
     @Bean
     public Config bridgeConfig() {
@@ -72,12 +65,19 @@ public class SpringConfig {
     }
 
     @Bean
-    public SignInCredentials bridgeWorkerCredentials() {
+    public ClientManager bridgeClientManager() {
+        ClientInfo clientInfo = new ClientInfo().appName("BridgeEX").appVersion(2);
+        return new ClientManager.Builder().withClientInfo(clientInfo).withSignIn(bridgeCredentials()).build();
+    }
+
+    @Bean
+    public SignIn bridgeCredentials() {
+        // sign-in credentials
         Config config = bridgeConfig();
         String study = config.get("bridge.worker.study");
         String email = config.get("bridge.worker.email");
         String password = config.get("bridge.worker.password");
-        return new SignInCredentials(study, email, password);
+        return new SignIn().study(study).email(email).password(password);
     }
 
     @Bean

--- a/src/main/java/org/sagebionetworks/bridge/exporter/handler/IosSurveyExportHandler.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/handler/IosSurveyExportHandler.java
@@ -14,8 +14,8 @@ import org.sagebionetworks.bridge.exporter.metrics.Metrics;
 import org.sagebionetworks.bridge.exporter.worker.ExportSubtask;
 import org.sagebionetworks.bridge.exporter.worker.ExportTask;
 import org.sagebionetworks.bridge.exporter.worker.ExportWorkerManager;
+import org.sagebionetworks.bridge.rest.model.UploadSchema;
 import org.sagebionetworks.bridge.schema.UploadSchemaKey;
-import org.sagebionetworks.bridge.sdk.models.upload.UploadSchema;
 
 /**
  * This class is responsible for converting the raw survey answers into a form the Synapse Export Worker can consume.

--- a/src/main/java/org/sagebionetworks/bridge/exporter/helper/ExportHelper.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/helper/ExportHelper.java
@@ -21,10 +21,10 @@ import org.sagebionetworks.bridge.config.Config;
 import org.sagebionetworks.bridge.exporter.exceptions.BridgeExporterException;
 import org.sagebionetworks.bridge.exporter.util.BridgeExporterUtil;
 import org.sagebionetworks.bridge.json.DefaultObjectMapper;
+import org.sagebionetworks.bridge.rest.model.UploadFieldDefinition;
+import org.sagebionetworks.bridge.rest.model.UploadSchema;
 import org.sagebionetworks.bridge.s3.S3Helper;
 import org.sagebionetworks.bridge.exporter.synapse.SynapseHelper;
-import org.sagebionetworks.bridge.sdk.models.upload.UploadFieldDefinition;
-import org.sagebionetworks.bridge.sdk.models.upload.UploadSchema;
 
 /**
  * This class contains utility methods that call multiple backend services that doesn't really fit into any of the

--- a/src/main/java/org/sagebionetworks/bridge/exporter/notification/S3EventNotificationCallback.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/notification/S3EventNotificationCallback.java
@@ -13,7 +13,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.sagebionetworks.bridge.exporter.helper.BridgeHelper;
-import org.sagebionetworks.bridge.sdk.exceptions.BridgeSDKException;
+import org.sagebionetworks.bridge.rest.exceptions.BridgeSDKException;
 import org.sagebionetworks.bridge.sqs.PollSqsCallback;
 
 @Component

--- a/src/main/java/org/sagebionetworks/bridge/exporter/synapse/SynapseHelper.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/synapse/SynapseHelper.java
@@ -39,10 +39,10 @@ import org.springframework.stereotype.Component;
 import org.sagebionetworks.bridge.config.Config;
 import org.sagebionetworks.bridge.exporter.exceptions.BridgeExporterException;
 import org.sagebionetworks.bridge.file.FileHelper;
+import org.sagebionetworks.bridge.rest.model.UploadFieldDefinition;
+import org.sagebionetworks.bridge.rest.model.UploadFieldType;
 import org.sagebionetworks.bridge.s3.S3Helper;
 import org.sagebionetworks.bridge.exporter.util.BridgeExporterUtil;
-import org.sagebionetworks.bridge.sdk.models.upload.UploadFieldDefinition;
-import org.sagebionetworks.bridge.sdk.models.upload.UploadFieldType;
 
 /** Helper class for Synapse calls, including complex logic around asynchronous calls and retry helper. */
 @Component
@@ -219,7 +219,7 @@ public class SynapseHelper {
                     nodeValue = node.toString();
                 }
 
-                Boolean isUnboundedText = fieldDef.isUnboundedText();
+                Boolean isUnboundedText = fieldDef.getUnboundedText();
                 Integer maxLength = null;
                 if (isUnboundedText == null || !isUnboundedText) {
                     maxLength = getMaxLengthForFieldDef(fieldDef);
@@ -510,8 +510,8 @@ public class SynapseHelper {
      */
     @RetryOnFailure(attempts = 2, delay = 1, unit = TimeUnit.SECONDS,
             types = { AmazonClientException.class, SynapseException.class }, randomize = false)
-    public FileHandle createFileHandleWithRetry(File file, String contentType, String projectId) throws IOException,
-            SynapseException {
+    public FileHandle createFileHandleWithRetry(File file, @SuppressWarnings("UnusedParameters") String contentType,
+            String projectId) throws IOException, SynapseException {
         UploadDestination uploadDestination = synapseClient.getDefaultUploadDestination(projectId);
         return synapseClient.multipartUpload(file, uploadDestination.getStorageLocationId(), null, null);
     }

--- a/src/main/java/org/sagebionetworks/bridge/exporter/util/BridgeExporterUtil.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/util/BridgeExporterUtil.java
@@ -13,9 +13,9 @@ import org.jsoup.safety.Whitelist;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.sagebionetworks.bridge.rest.model.UploadFieldDefinition;
+import org.sagebionetworks.bridge.rest.model.UploadSchema;
 import org.sagebionetworks.bridge.schema.UploadSchemaKey;
-import org.sagebionetworks.bridge.sdk.models.upload.UploadFieldDefinition;
-import org.sagebionetworks.bridge.sdk.models.upload.UploadSchema;
 
 /** Various static utility methods that don't neatly fit anywhere else. */
 public class BridgeExporterUtil {
@@ -83,8 +83,14 @@ public class BridgeExporterUtil {
      * @return schema key
      */
     public static UploadSchemaKey getSchemaKeyFromSchema(UploadSchema schema) {
+        // In the new JavaSDK, revision is a Long. However, in bridge-base UploadSchemaKey, revision is an Integer.
+        // There is no null-safe way to convert this. So do a null check and throw an IllegalArgumentException, so that
+        // we don't have to deal with a NullPointerException.
+        if (schema.getRevision() == null) {
+            throw new IllegalArgumentException("revision can't be null");
+        }
         return new UploadSchemaKey.Builder().withStudyId(schema.getStudyId()).withSchemaId(schema.getSchemaId())
-                .withRevision(schema.getRevision()).build();
+                .withRevision(schema.getRevision().intValue()).build();
     }
 
     /**

--- a/src/test/java/org/sagebionetworks/bridge/exporter/handler/HealthDataExportHandlerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/handler/HealthDataExportHandlerTest.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.node.BooleanNode;
 import com.fasterxml.jackson.databind.node.IntNode;
 import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.TextNode;
+import com.google.common.collect.ImmutableList;
 import org.joda.time.DateTime;
 import org.sagebionetworks.repo.model.table.ColumnModel;
 import org.testng.annotations.DataProvider;
@@ -38,20 +39,20 @@ import org.sagebionetworks.bridge.exporter.worker.ExportTask;
 import org.sagebionetworks.bridge.exporter.worker.ExportWorkerManager;
 import org.sagebionetworks.bridge.file.InMemoryFileHelper;
 import org.sagebionetworks.bridge.json.DefaultObjectMapper;
-import org.sagebionetworks.bridge.sdk.models.upload.UploadFieldDefinition;
-import org.sagebionetworks.bridge.sdk.models.upload.UploadFieldType;
+import org.sagebionetworks.bridge.rest.model.UploadFieldDefinition;
+import org.sagebionetworks.bridge.rest.model.UploadFieldType;
 
 public class HealthDataExportHandlerTest {
     private static final String FIELD_NAME = "foo-field";
     private static final String FIELD_NAME_TIMEZONE = FIELD_NAME + ".timezone";
     private static final String FIELD_VALUE = "asdf jkl;";
 
-    private static final UploadFieldDefinition MULTI_CHOICE_FIELD_DEF = new UploadFieldDefinition.Builder()
-            .withName(FIELD_NAME).withType(UploadFieldType.MULTI_CHOICE).withMultiChoiceAnswerList("foo", "bar", "baz",
-                    "true", "42").build();
-    private static final UploadFieldDefinition OTHER_CHOICE_FIELD_DEF = new UploadFieldDefinition.Builder()
-            .withAllowOtherChoices(true).withName(FIELD_NAME).withType(UploadFieldType.MULTI_CHOICE)
-            .withMultiChoiceAnswerList("one", "two").build();
+    private static final UploadFieldDefinition MULTI_CHOICE_FIELD_DEF = new UploadFieldDefinition().name(FIELD_NAME)
+            .type(UploadFieldType.MULTI_CHOICE).multiChoiceAnswerList(ImmutableList.of("foo", "bar", "baz", "true",
+                    "42"));
+    private static final UploadFieldDefinition OTHER_CHOICE_FIELD_DEF = new UploadFieldDefinition()
+            .allowOtherChoices(true).name(FIELD_NAME).type(UploadFieldType.MULTI_CHOICE)
+            .multiChoiceAnswerList(ImmutableList.of("one", "two"));
 
     // branch coverage
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/exporter/handler/SynapseExportHandlerNewTableTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/handler/SynapseExportHandlerNewTableTest.java
@@ -17,6 +17,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.google.common.collect.ImmutableList;
 import org.sagebionetworks.repo.model.table.ColumnModel;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -32,10 +33,10 @@ import org.sagebionetworks.bridge.exporter.worker.ExportSubtask;
 import org.sagebionetworks.bridge.exporter.worker.ExportTask;
 import org.sagebionetworks.bridge.exporter.worker.ExportWorkerManager;
 import org.sagebionetworks.bridge.file.InMemoryFileHelper;
+import org.sagebionetworks.bridge.rest.model.UploadFieldDefinition;
+import org.sagebionetworks.bridge.rest.model.UploadFieldType;
+import org.sagebionetworks.bridge.rest.model.UploadSchema;
 import org.sagebionetworks.bridge.schema.UploadSchemaKey;
-import org.sagebionetworks.bridge.sdk.models.upload.UploadFieldDefinition;
-import org.sagebionetworks.bridge.sdk.models.upload.UploadFieldType;
-import org.sagebionetworks.bridge.sdk.models.upload.UploadSchema;
 
 public class SynapseExportHandlerNewTableTest {
     private String ddbSynapseTableId;
@@ -185,10 +186,9 @@ public class SynapseExportHandlerNewTableTest {
     public void healthDataExportHandlerTest() throws Exception {
         // Freeform text to attachments is already tested in SynapseExportHandlerTest. Just test simple string and int
         // fields.
-        UploadSchema testSchema = BridgeHelperTest.simpleSchemaBuilder().withFieldDefinitions(
-                new UploadFieldDefinition.Builder().withName("foo").withType(UploadFieldType.STRING).build(),
-                new UploadFieldDefinition.Builder().withName("bar").withType(UploadFieldType.INT).build())
-                .build();
+        UploadSchema testSchema = BridgeHelperTest.simpleSchemaBuilder().fieldDefinitions(ImmutableList.of(
+                new UploadFieldDefinition().name("foo").type(UploadFieldType.STRING),
+                new UploadFieldDefinition().name("bar").type(UploadFieldType.INT)));
         UploadSchemaKey testSchemaKey = BridgeExporterUtil.getSchemaKeyFromSchema(testSchema);
 
         // Set up handler and test. setSchema() needs to be called before setup, since a lot of the stuff in the

--- a/src/test/java/org/sagebionetworks/bridge/exporter/helper/ExportHelperConvertSurveyTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/helper/ExportHelperConvertSurveyTest.java
@@ -11,6 +11,7 @@ import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableList;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -18,10 +19,10 @@ import org.sagebionetworks.bridge.config.Config;
 import org.sagebionetworks.bridge.exporter.exceptions.BridgeExporterException;
 import org.sagebionetworks.bridge.exporter.util.BridgeExporterUtil;
 import org.sagebionetworks.bridge.json.DefaultObjectMapper;
+import org.sagebionetworks.bridge.rest.model.UploadFieldDefinition;
+import org.sagebionetworks.bridge.rest.model.UploadFieldType;
+import org.sagebionetworks.bridge.rest.model.UploadSchema;
 import org.sagebionetworks.bridge.s3.S3Helper;
-import org.sagebionetworks.bridge.sdk.models.upload.UploadFieldDefinition;
-import org.sagebionetworks.bridge.sdk.models.upload.UploadFieldType;
-import org.sagebionetworks.bridge.sdk.models.upload.UploadSchema;
 
 public class ExportHelperConvertSurveyTest {
     private static final String DUMMY_ANSWERS_ATTACHMENT_ID = "answers-attachment-id";
@@ -92,25 +93,24 @@ public class ExportHelperConvertSurveyTest {
     @Test
     public void normalCase() throws Exception {
         // Make schema with all fields from the below answers.
-        UploadSchema testSchema = BridgeHelperTest.simpleSchemaBuilder().withFieldDefinitions(
-                new UploadFieldDefinition.Builder().withName("no-question-type-name").withType(UploadFieldType.STRING)
-                        .build(),
-                new UploadFieldDefinition.Builder().withName("fallback-to-question-type")
-                        .withType(UploadFieldType.STRING).build(),
-                new UploadFieldDefinition.Builder().withName("bad-type").withType(UploadFieldType.STRING).build(),
-                new UploadFieldDefinition.Builder().withName("null-value").withType(UploadFieldType.STRING).build(),
-                new UploadFieldDefinition.Builder().withName("inline-string").withType(UploadFieldType.STRING).build(),
-                new UploadFieldDefinition.Builder().withName("attachment-string")
-                        .withType(UploadFieldType.ATTACHMENT_JSON_BLOB).build(),
-                new UploadFieldDefinition.Builder().withName("integer").withType(UploadFieldType.INT).build(),
-                new UploadFieldDefinition.Builder().withName("integer_unit").withType(UploadFieldType.STRING).build(),
-                new UploadFieldDefinition.Builder().withName("single-choice")
-                        .withType(UploadFieldType.INLINE_JSON_BLOB).build(),
-                new UploadFieldDefinition.Builder().withName("inline-multiple-choice")
-                        .withType(UploadFieldType.INLINE_JSON_BLOB).build(),
-                new UploadFieldDefinition.Builder().withName("attachment-multiple-choice")
-                        .withType(UploadFieldType.ATTACHMENT_JSON_BLOB).build())
-                .build();
+        UploadSchema testSchema = BridgeHelperTest.simpleSchemaBuilder().fieldDefinitions(ImmutableList.of(
+                new UploadFieldDefinition().name("no-question-type-name").type(UploadFieldType.STRING)
+                        ,
+                new UploadFieldDefinition().name("fallback-to-question-type")
+                        .type(UploadFieldType.STRING),
+                new UploadFieldDefinition().name("bad-type").type(UploadFieldType.STRING),
+                new UploadFieldDefinition().name("null-value").type(UploadFieldType.STRING),
+                new UploadFieldDefinition().name("inline-string").type(UploadFieldType.STRING),
+                new UploadFieldDefinition().name("attachment-string")
+                        .type(UploadFieldType.ATTACHMENT_JSON_BLOB),
+                new UploadFieldDefinition().name("integer").type(UploadFieldType.INT),
+                new UploadFieldDefinition().name("integer_unit").type(UploadFieldType.STRING),
+                new UploadFieldDefinition().name("single-choice")
+                        .type(UploadFieldType.INLINE_JSON_BLOB),
+                new UploadFieldDefinition().name("inline-multiple-choice")
+                        .type(UploadFieldType.INLINE_JSON_BLOB),
+                new UploadFieldDefinition().name("attachment-multiple-choice")
+                        .type(UploadFieldType.ATTACHMENT_JSON_BLOB)));
 
         // Make answers array. This is semi-realistic.
         String answersAttachmentText = "[\n" +

--- a/src/test/java/org/sagebionetworks/bridge/exporter/notification/S3EventNotificationCallbackTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/notification/S3EventNotificationCallbackTest.java
@@ -23,7 +23,7 @@ import org.testng.annotations.Test;
 import com.google.common.collect.Lists;
 
 import org.sagebionetworks.bridge.exporter.helper.BridgeHelper;
-import org.sagebionetworks.bridge.sdk.exceptions.BridgeSDKException;
+import org.sagebionetworks.bridge.rest.exceptions.BridgeSDKException;
 
 public class S3EventNotificationCallbackTest {
 

--- a/src/test/java/org/sagebionetworks/bridge/exporter/synapse/SynapseHelperSerializeTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/synapse/SynapseHelperSerializeTest.java
@@ -21,8 +21,8 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.json.DefaultObjectMapper;
-import org.sagebionetworks.bridge.sdk.models.upload.UploadFieldDefinition;
-import org.sagebionetworks.bridge.sdk.models.upload.UploadFieldType;
+import org.sagebionetworks.bridge.rest.model.UploadFieldDefinition;
+import org.sagebionetworks.bridge.rest.model.UploadFieldType;
 
 // Tests for SynapseHelper.serializeToSynapseType()
 public class SynapseHelperSerializeTest {
@@ -164,8 +164,8 @@ public class SynapseHelperSerializeTest {
     @Test(dataProvider = "stringTypeProvider")
     public void stringSanitized(UploadFieldType stringType) throws Exception {
         // Use an extra short field def.
-        UploadFieldDefinition fieldDef = new UploadFieldDefinition.Builder().withName(TEST_FIELD_NAME)
-                .withType(stringType).withMaxLength(10).build();
+        UploadFieldDefinition fieldDef = new UploadFieldDefinition().name(TEST_FIELD_NAME).type(stringType)
+                .maxLength(10);
 
         // String value has newlines and tabs that need to be stripped out.
         String input = "asdf\njkl;\tlorem ipsum dolor";
@@ -187,8 +187,8 @@ public class SynapseHelperSerializeTest {
     // branch coverage
     @Test(dataProvider = "stringTypeProvider")
     public void stringUnboundedTrue(UploadFieldType stringType) throws Exception {
-        UploadFieldDefinition fieldDef = new UploadFieldDefinition.Builder().withName(TEST_FIELD_NAME)
-                .withType(stringType).withUnboundedText(true).build();
+        UploadFieldDefinition fieldDef = new UploadFieldDefinition().name(TEST_FIELD_NAME).type(stringType).
+                unboundedText(true);
         String retVal = new SynapseHelper().serializeToSynapseType(MOCK_TEMP_DIR, TEST_PROJECT_ID, TEST_RECORD_ID,
                 fieldDef, new TextNode("unbounded text not really"));
         assertEquals(retVal, "unbounded text not really");
@@ -197,8 +197,8 @@ public class SynapseHelperSerializeTest {
     // branch coverage
     @Test(dataProvider = "stringTypeProvider")
     public void stringUnboundedFalse(UploadFieldType stringType) throws Exception {
-        UploadFieldDefinition fieldDef = new UploadFieldDefinition.Builder().withName(TEST_FIELD_NAME)
-                .withType(stringType).withUnboundedText(false).build();
+        UploadFieldDefinition fieldDef = new UploadFieldDefinition().name(TEST_FIELD_NAME).type(stringType)
+                .unboundedText(false);
         String retVal = new SynapseHelper().serializeToSynapseType(MOCK_TEMP_DIR, TEST_PROJECT_ID, TEST_RECORD_ID,
                 fieldDef, new TextNode("not really unbounded text"));
         assertEquals(retVal, "not really unbounded text");
@@ -263,6 +263,6 @@ public class SynapseHelperSerializeTest {
     }
 
     private static UploadFieldDefinition fieldDefForType(UploadFieldType type) {
-        return new UploadFieldDefinition.Builder().withName(TEST_FIELD_NAME).withType(type).build();
+        return new UploadFieldDefinition().name(TEST_FIELD_NAME).type(type);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/exporter/synapse/SynapseHelperTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/synapse/SynapseHelperTest.java
@@ -36,8 +36,8 @@ import org.sagebionetworks.repo.model.table.UploadToTableResult;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import org.sagebionetworks.bridge.sdk.models.upload.UploadFieldDefinition;
-import org.sagebionetworks.bridge.sdk.models.upload.UploadFieldType;
+import org.sagebionetworks.bridge.rest.model.UploadFieldDefinition;
+import org.sagebionetworks.bridge.rest.model.UploadFieldType;
 
 @SuppressWarnings({ "unchecked", "rawtypes" })
 public class SynapseHelperTest {
@@ -45,20 +45,13 @@ public class SynapseHelperTest {
     public Object[][] maxLengthTestDataProvider() {
         // { fieldDef, expectedMaxLength }
         return new Object[][] {
-                { new UploadFieldDefinition.Builder().withName("dummy").withType(UploadFieldType.CALENDAR_DATE)
-                        .build(), 10 },
-                { new UploadFieldDefinition.Builder().withName("dummy").withType(UploadFieldType.DURATION_V2).build(),
-                        24 },
-                { new UploadFieldDefinition.Builder().withName("dummy").withType(UploadFieldType.INLINE_JSON_BLOB)
-                        .build(), 100 },
-                { new UploadFieldDefinition.Builder().withName("dummy").withType(UploadFieldType.SINGLE_CHOICE)
-                        .build(), 100 },
-                { new UploadFieldDefinition.Builder().withName("dummy").withType(UploadFieldType.STRING).build(),
-                        100 },
-                { new UploadFieldDefinition.Builder().withName("dummy").withType(UploadFieldType.TIME_V2).build(),
-                        12 },
-                { new UploadFieldDefinition.Builder().withName("dummy").withType(UploadFieldType.STRING)
-                        .withMaxLength(256).build(), 256 },
+                { new UploadFieldDefinition().name("dummy").type(UploadFieldType.CALENDAR_DATE), 10 },
+                { new UploadFieldDefinition().name("dummy").type(UploadFieldType.DURATION_V2), 24 },
+                { new UploadFieldDefinition().name("dummy").type(UploadFieldType.INLINE_JSON_BLOB), 100 },
+                { new UploadFieldDefinition().name("dummy").type(UploadFieldType.SINGLE_CHOICE), 100 },
+                { new UploadFieldDefinition().name("dummy").type(UploadFieldType.STRING), 100 },
+                { new UploadFieldDefinition().name("dummy").type(UploadFieldType.TIME_V2), 12 },
+                { new UploadFieldDefinition().name("dummy").type(UploadFieldType.STRING).maxLength(256), 256 },
         };
     }
 

--- a/src/test/java/org/sagebionetworks/bridge/exporter/synapse/SynapseHelperUploadAttachmentTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/synapse/SynapseHelperUploadAttachmentTest.java
@@ -26,9 +26,9 @@ import org.sagebionetworks.bridge.config.Config;
 import org.sagebionetworks.bridge.exporter.util.BridgeExporterUtil;
 import org.sagebionetworks.bridge.file.FileHelper;
 import org.sagebionetworks.bridge.file.InMemoryFileHelper;
+import org.sagebionetworks.bridge.rest.model.UploadFieldDefinition;
+import org.sagebionetworks.bridge.rest.model.UploadFieldType;
 import org.sagebionetworks.bridge.s3.S3Helper;
-import org.sagebionetworks.bridge.sdk.models.upload.UploadFieldDefinition;
-import org.sagebionetworks.bridge.sdk.models.upload.UploadFieldType;
 
 // Tests for SynapseHelper.uploadFromS3ToSynapseFileHandle() and related methods.
 @SuppressWarnings("unchecked")
@@ -37,85 +37,85 @@ public class SynapseHelperUploadAttachmentTest {
 
     @Test
     public void filenameFromFieldDef() {
-        UploadFieldDefinition fieldDef = new UploadFieldDefinition.Builder().withName("test.foo")
-                .withType(UploadFieldType.ATTACHMENT_V2).withFileExtension(".foo").build();
+        UploadFieldDefinition fieldDef = new UploadFieldDefinition().name("test.foo")
+                .type(UploadFieldType.ATTACHMENT_V2).fileExtension(".foo");
         String filename = SynapseHelper.generateFilename(fieldDef, TEST_ATTACHMENT_ID);
         assertEquals(filename, "test-attId.foo");
     }
 
     @Test
     public void filenameFromFieldDefMismatchedExtension() {
-        UploadFieldDefinition fieldDef = new UploadFieldDefinition.Builder().withName("test.bar")
-                .withType(UploadFieldType.ATTACHMENT_V2).withFileExtension(".foo").build();
+        UploadFieldDefinition fieldDef = new UploadFieldDefinition().name("test.bar")
+                .type(UploadFieldType.ATTACHMENT_V2).fileExtension(".foo");
         String filename = SynapseHelper.generateFilename(fieldDef, TEST_ATTACHMENT_ID);
         assertEquals(filename, "test.bar-attId.foo");
     }
 
     @Test
     public void filenameJsonBlob() {
-        assertEquals(SynapseHelper.generateFilename(new UploadFieldDefinition.Builder().withName("test.json.blob")
-            .withType(UploadFieldType.ATTACHMENT_JSON_BLOB).build(), TEST_ATTACHMENT_ID), "test.json.blob-attId.json");
+        assertEquals(SynapseHelper.generateFilename(new UploadFieldDefinition().name("test.json.blob")
+            .type(UploadFieldType.ATTACHMENT_JSON_BLOB), TEST_ATTACHMENT_ID), "test.json.blob-attId.json");
     }
 
     @Test
     public void filenameJsonTable() {
-        assertEquals(SynapseHelper.generateFilename(new UploadFieldDefinition.Builder().withName("test.json.table")
-                        .withType(UploadFieldType.ATTACHMENT_JSON_TABLE).build(), TEST_ATTACHMENT_ID),
+        assertEquals(SynapseHelper.generateFilename(new UploadFieldDefinition().name("test.json.table")
+                        .type(UploadFieldType.ATTACHMENT_JSON_TABLE), TEST_ATTACHMENT_ID),
                 "test.json.table-attId.json");
     }
 
     @Test
     public void filenameJsonWithJsonExtension() {
-        assertEquals(SynapseHelper.generateFilename(new UploadFieldDefinition.Builder().withName("test.json")
-                .withType(UploadFieldType.ATTACHMENT_JSON_BLOB).build(), TEST_ATTACHMENT_ID), "test-attId.json");
+        assertEquals(SynapseHelper.generateFilename(new UploadFieldDefinition().name("test.json")
+                .type(UploadFieldType.ATTACHMENT_JSON_BLOB), TEST_ATTACHMENT_ID), "test-attId.json");
     }
 
     @Test
     public void filenameCsv() {
-        assertEquals(SynapseHelper.generateFilename(new UploadFieldDefinition.Builder().withName("csv.data")
-                .withType(UploadFieldType.ATTACHMENT_CSV).build(), TEST_ATTACHMENT_ID), "csv.data-attId.csv");
+        assertEquals(SynapseHelper.generateFilename(new UploadFieldDefinition().name("csv.data")
+                .type(UploadFieldType.ATTACHMENT_CSV), TEST_ATTACHMENT_ID), "csv.data-attId.csv");
     }
 
     @Test
     public void filenameCsvWithCsvExtension() {
-        assertEquals(SynapseHelper.generateFilename(new UploadFieldDefinition.Builder().withName("data.csv")
-                .withType(UploadFieldType.ATTACHMENT_CSV).build(), TEST_ATTACHMENT_ID), "data-attId.csv");
+        assertEquals(SynapseHelper.generateFilename(new UploadFieldDefinition().name("data.csv")
+                .type(UploadFieldType.ATTACHMENT_CSV), TEST_ATTACHMENT_ID), "data-attId.csv");
     }
 
     @Test
     public void filenameBlob() {
-        assertEquals(SynapseHelper.generateFilename(new UploadFieldDefinition.Builder().withName("generic.blob")
-                .withType(UploadFieldType.ATTACHMENT_BLOB).build(), TEST_ATTACHMENT_ID), "generic-attId.blob");
+        assertEquals(SynapseHelper.generateFilename(new UploadFieldDefinition().name("generic.blob")
+                .type(UploadFieldType.ATTACHMENT_BLOB), TEST_ATTACHMENT_ID), "generic-attId.blob");
     }
 
     @Test
     public void filenameBlobWithNoExtension() {
-        assertEquals(SynapseHelper.generateFilename(new UploadFieldDefinition.Builder().withName("genericBlob")
-                .withType(UploadFieldType.ATTACHMENT_BLOB).build(), TEST_ATTACHMENT_ID), "genericBlob-attId");
+        assertEquals(SynapseHelper.generateFilename(new UploadFieldDefinition().name("genericBlob")
+                .type(UploadFieldType.ATTACHMENT_BLOB), TEST_ATTACHMENT_ID), "genericBlob-attId");
     }
 
     @Test
     public void filenameBlobWithMultipleDots() {
-        assertEquals(SynapseHelper.generateFilename(new UploadFieldDefinition.Builder().withName("generic.blob.ext")
-                .withType(UploadFieldType.ATTACHMENT_BLOB).build(), TEST_ATTACHMENT_ID), "generic.blob-attId.ext");
+        assertEquals(SynapseHelper.generateFilename(new UploadFieldDefinition().name("generic.blob.ext")
+                .type(UploadFieldType.ATTACHMENT_BLOB), TEST_ATTACHMENT_ID), "generic.blob-attId.ext");
     }
 
     @Test
     public void filenameBlobStartsWithDot() {
-        assertEquals(SynapseHelper.generateFilename(new UploadFieldDefinition.Builder().withName(".dot")
-                .withType(UploadFieldType.ATTACHMENT_BLOB).build(), TEST_ATTACHMENT_ID), ".dot-attId");
+        assertEquals(SynapseHelper.generateFilename(new UploadFieldDefinition().name(".dot")
+                .type(UploadFieldType.ATTACHMENT_BLOB), TEST_ATTACHMENT_ID), ".dot-attId");
     }
 
     @Test
     public void filenameBlobStartsWithDotWithExtension() {
-        assertEquals(SynapseHelper.generateFilename(new UploadFieldDefinition.Builder().withName(".dot.ext")
-                .withType(UploadFieldType.ATTACHMENT_BLOB).build(), TEST_ATTACHMENT_ID), ".dot-attId.ext");
+        assertEquals(SynapseHelper.generateFilename(new UploadFieldDefinition().name(".dot.ext")
+                .type(UploadFieldType.ATTACHMENT_BLOB), TEST_ATTACHMENT_ID), ".dot-attId.ext");
     }
 
     @Test
     public void filenameBlobEndsWithDot() {
-        assertEquals(SynapseHelper.generateFilename(new UploadFieldDefinition.Builder().withName("dot.dot.")
-                .withType(UploadFieldType.ATTACHMENT_BLOB).build(), TEST_ATTACHMENT_ID), "dot.dot.-attId");
+        assertEquals(SynapseHelper.generateFilename(new UploadFieldDefinition().name("dot.dot.")
+                .type(UploadFieldType.ATTACHMENT_BLOB), TEST_ATTACHMENT_ID), "dot.dot.-attId");
     }
 
     private static final String DUMMY_FILE_CONTENT = "This is some file content.";
@@ -127,18 +127,18 @@ public class SynapseHelperUploadAttachmentTest {
     public Object[][] uploadTestDataProvider() {
         // { fieldDef, expectedFilename, expectedMimeType }
         return new Object[][] {
-                { new UploadFieldDefinition.Builder().withName("foo.blob").withType(UploadFieldType.ATTACHMENT_BLOB)
-                        .build(), "foo-attId.blob", "application/octet-stream" },
-                { new UploadFieldDefinition.Builder().withName("bar.csv").withType(UploadFieldType.ATTACHMENT_CSV)
-                        .build(), "bar-attId.csv", "text/csv" },
-                { new UploadFieldDefinition.Builder().withName("baz.json")
-                        .withType(UploadFieldType.ATTACHMENT_JSON_BLOB).build(), "baz-attId.json", "text/json" },
-                { new UploadFieldDefinition.Builder().withName("qwerty.json")
-                        .withType(UploadFieldType.ATTACHMENT_JSON_TABLE).build(), "qwerty-attId.json", "text/json" },
-                { new UploadFieldDefinition.Builder().withName("asdf.file").withType(UploadFieldType.ATTACHMENT_V2)
-                        .build(), "asdf-attId.file", "application/octet-stream" },
-                { new UploadFieldDefinition.Builder().withName("jkl.txt").withType(UploadFieldType.ATTACHMENT_V2)
-                        .withFileExtension(".txt").withMimeType("text/plain").build(), "jkl-attId.txt", "text/plain" },
+                { new UploadFieldDefinition().name("foo.blob").type(UploadFieldType.ATTACHMENT_BLOB),"foo-attId.blob",
+                        "application/octet-stream" },
+                { new UploadFieldDefinition().name("bar.csv").type(UploadFieldType.ATTACHMENT_CSV), "bar-attId.csv",
+                        "text/csv" },
+                { new UploadFieldDefinition().name("baz.json").type(UploadFieldType.ATTACHMENT_JSON_BLOB),
+                        "baz-attId.json", "text/json" },
+                { new UploadFieldDefinition().name("qwerty.json").type(UploadFieldType.ATTACHMENT_JSON_TABLE),
+                        "qwerty-attId.json", "text/json" },
+                { new UploadFieldDefinition().name("asdf.file").type(UploadFieldType.ATTACHMENT_V2), "asdf-attId.file",
+                        "application/octet-stream" },
+                { new UploadFieldDefinition().name("jkl.txt").type(UploadFieldType.ATTACHMENT_V2).fileExtension(".txt")
+                        .mimeType("text/plain"), "jkl-attId.txt", "text/plain" },
         };
     }
 
@@ -203,8 +203,8 @@ public class SynapseHelperUploadAttachmentTest {
 
         // execute and validate
         try {
-            synapseHelper.uploadFromS3ToSynapseFileHandle(tmpDir, TEST_PROJECT_ID, new UploadFieldDefinition.Builder()
-                    .withName("test.blob").withType(UploadFieldType.ATTACHMENT_BLOB).build(), TEST_ATTACHMENT_ID);
+            synapseHelper.uploadFromS3ToSynapseFileHandle(tmpDir, TEST_PROJECT_ID, new UploadFieldDefinition()
+                    .name("test.blob").type(UploadFieldType.ATTACHMENT_BLOB), TEST_ATTACHMENT_ID);
             fail("expected exception");
         } catch (SynapseException ex) {
             // expected exception

--- a/src/test/java/org/sagebionetworks/bridge/exporter/util/BridgeExporterUtilTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/util/BridgeExporterUtilTest.java
@@ -13,20 +13,19 @@ import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.exporter.helper.BridgeHelperTest;
 import org.sagebionetworks.bridge.json.DefaultObjectMapper;
+import org.sagebionetworks.bridge.rest.model.UploadFieldDefinition;
+import org.sagebionetworks.bridge.rest.model.UploadFieldType;
+import org.sagebionetworks.bridge.rest.model.UploadSchema;
 import org.sagebionetworks.bridge.schema.UploadSchemaKey;
-import org.sagebionetworks.bridge.sdk.models.upload.UploadFieldDefinition;
-import org.sagebionetworks.bridge.sdk.models.upload.UploadFieldType;
-import org.sagebionetworks.bridge.sdk.models.upload.UploadSchema;
 
 public class BridgeExporterUtilTest {
     @Test
     public void getFieldDefMapFromSchema() {
         // set up test schema
-        UploadFieldDefinition fooField = new UploadFieldDefinition.Builder().withName("foo")
-                .withType(UploadFieldType.STRING).build();
-        UploadFieldDefinition barField = new UploadFieldDefinition.Builder().withName("bar")
-                .withType(UploadFieldType.INT).build();
-        UploadSchema schema = BridgeHelperTest.simpleSchemaBuilder().withFieldDefinitions(fooField, barField).build();
+        UploadFieldDefinition fooField = new UploadFieldDefinition().name("foo").type(UploadFieldType.STRING);
+        UploadFieldDefinition barField = new UploadFieldDefinition().name("bar").type(UploadFieldType.INT);
+        UploadSchema schema = BridgeHelperTest.simpleSchemaBuilder().addFieldDefinitionsItem(fooField)
+                .addFieldDefinitionsItem(barField);
 
         // execute and validate
         Map<String, UploadFieldDefinition> fieldDefMap = BridgeExporterUtil.getFieldDefMapFromSchema(schema);
@@ -47,16 +46,28 @@ public class BridgeExporterUtilTest {
     @Test
     public void getSchemaKeyFromSchema() {
         // set up test schema
-        UploadFieldDefinition fooField = new UploadFieldDefinition.Builder().withName("foo")
-                .withType(UploadFieldType.STRING).build();
-        UploadSchema schema = BridgeHelperTest.simpleSchemaBuilder().withStudyId("test-study")
-                .withSchemaId("test-schema").withRevision(3).withFieldDefinitions(fooField).build();
+        UploadFieldDefinition fooField = new UploadFieldDefinition().name("foo").type(UploadFieldType.STRING);
+        UploadSchema schema = BridgeHelperTest.simpleSchemaBuilder().studyId("test-study").schemaId("test-schema")
+                .revision(3L).addFieldDefinitionsItem(fooField);
 
         // execute and validate
         UploadSchemaKey schemaKey = BridgeExporterUtil.getSchemaKeyFromSchema(schema);
         assertEquals(schemaKey.getStudyId(), "test-study");
         assertEquals(schemaKey.getSchemaId(), "test-schema");
         assertEquals(schemaKey.getRevision(), 3);
+    }
+
+    // branch coverage
+    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp =
+            "revision can't be null")
+    public void getSchemaKeyNullRev() {
+        // set up test schema
+        UploadFieldDefinition fooField = new UploadFieldDefinition().name("foo").type(UploadFieldType.STRING);
+        UploadSchema schema = BridgeHelperTest.simpleSchemaBuilder().studyId("test-study").schemaId("test-schema")
+                .revision(null).addFieldDefinitionsItem(fooField);
+
+        // execute and validate
+        BridgeExporterUtil.getSchemaKeyFromSchema(schema);
     }
 
     @Test


### PR DESCRIPTION
This migrates to the new Bridge REST Client, which ensures that we're using the most up-to-date APIs and library versions.

Testing done:
* mvn verify (unit tests, findbugs, jacoco test coverage)
* manual tests

Manual Testing done:
* export, using schema upload-v2-manual-test to test a variety of fields
* verified recordExportStatus
* upload autocomplete
* refresh sessions (both export and upload autocomplete)