### PR TITLE
improve redrive logic

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/exporter/exceptions/BridgeExporterNonRetryableException.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/exceptions/BridgeExporterNonRetryableException.java
@@ -1,0 +1,22 @@
+package org.sagebionetworks.bridge.exporter.exceptions;
+
+/**
+ * A special kind of BridgeExporterException. This represents a deterministic error that BridgeEX knows not to retry.
+ */
+@SuppressWarnings("serial")
+public class BridgeExporterNonRetryableException extends BridgeExporterException {
+    public BridgeExporterNonRetryableException() {
+    }
+
+    public BridgeExporterNonRetryableException(String message) {
+        super(message);
+    }
+
+    public BridgeExporterNonRetryableException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public BridgeExporterNonRetryableException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/org/sagebionetworks/bridge/exporter/exceptions/BridgeExporterTsvException.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/exceptions/BridgeExporterTsvException.java
@@ -1,0 +1,25 @@
+package org.sagebionetworks.bridge.exporter.exceptions;
+
+/**
+ * A special kind of BridgeExporterException, which represents a TSV initialization failure. This exception itself
+ * isn't thrown when the TSV is initialized, but is rather thrown later in the call chain when later calls attempt to
+ * write to the TSV. This exception generally wraps the underlying cause so that later calls in the call chain can
+ * handle the error appropriately.
+ */
+@SuppressWarnings("serial")
+public class BridgeExporterTsvException extends BridgeExporterException {
+    public BridgeExporterTsvException() {
+    }
+
+    public BridgeExporterTsvException(String message) {
+        super(message);
+    }
+
+    public BridgeExporterTsvException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public BridgeExporterTsvException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/org/sagebionetworks/bridge/exporter/handler/SynapseExportHandler.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/handler/SynapseExportHandler.java
@@ -18,7 +18,8 @@ import com.amazonaws.services.dynamodbv2.document.Item;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
-import org.sagebionetworks.bridge.exporter.helper.BridgeHelper;
+
+import org.sagebionetworks.bridge.exporter.exceptions.BridgeExporterNonRetryableException;
 import org.sagebionetworks.client.exceptions.SynapseException;
 import org.sagebionetworks.repo.model.table.ColumnModel;
 import org.sagebionetworks.repo.model.table.ColumnType;
@@ -162,7 +163,7 @@ public abstract class SynapseExportHandler extends ExportHandler {
             tsvInfo = new TsvInfo(columnNameList, tsvFile, tsvWriter);
         } catch (BridgeExporterException | FileNotFoundException | SchemaNotFoundException | SynapseException ex) {
             LOG.error("Error initializing TSV for table " + getDdbTableKeyValue() + ": " + ex.getMessage(), ex);
-            tsvInfo = TsvInfo.INIT_ERROR_TSV_INFO;
+            tsvInfo = new TsvInfo(ex);
         }
 
         setTsvInfoForTask(task, tsvInfo);
@@ -274,7 +275,7 @@ public abstract class SynapseExportHandler extends ExportHandler {
         }
 
         if (shouldThrow) {
-            throw new BridgeExporterException("Table has deleted and/or modified columns");
+            throw new BridgeExporterNonRetryableException("Table has deleted and/or modified columns");
         }
 
         // Optimization: Were any columns added?
@@ -402,11 +403,9 @@ public abstract class SynapseExportHandler extends ExportHandler {
 
     /**
      * dummy method to implement by healthDataExportHandler to handle update record exporter status
-     * @param tsvInfo
      * @throws BridgeExporterException
      */
     protected void postProcessTsv(TsvInfo tsvInfo) throws BridgeExporterException {
 
-    };
-
+    }
 }

--- a/src/test/java/org/sagebionetworks/bridge/exporter/handler/SynapseExportHandlerUpdateTableTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/handler/SynapseExportHandlerUpdateTableTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 import java.io.File;
@@ -32,6 +33,8 @@ import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.config.Config;
 import org.sagebionetworks.bridge.exporter.exceptions.BridgeExporterException;
+import org.sagebionetworks.bridge.exporter.exceptions.BridgeExporterNonRetryableException;
+import org.sagebionetworks.bridge.exporter.exceptions.BridgeExporterTsvException;
 import org.sagebionetworks.bridge.exporter.metrics.Metrics;
 import org.sagebionetworks.bridge.exporter.synapse.SynapseHelper;
 import org.sagebionetworks.bridge.exporter.util.TestUtil;
@@ -203,7 +206,10 @@ public class SynapseExportHandlerUpdateTableTest {
             handler.uploadToSynapseForTask(task);
             fail("expected exception");
         } catch (BridgeExporterException ex) {
-            // expected exception
+            assertTrue(ex instanceof BridgeExporterTsvException);
+            assertTrue(ex.getMessage().startsWith("TSV was not successfully initialized: "));
+            assertTrue(ex.getCause() instanceof BridgeExporterNonRetryableException);
+            assertEquals(ex.getCause().getMessage(), "Table has deleted and/or modified columns");
         }
 
         // verify we did not update the table
@@ -228,7 +234,10 @@ public class SynapseExportHandlerUpdateTableTest {
             handler.handle(subtask);
             fail("expected exception");
         } catch (BridgeExporterException ex) {
-            assertEquals(ex.getMessage(), "TSV was not successfully initialized");
+            assertTrue(ex instanceof BridgeExporterTsvException);
+            assertTrue(ex.getMessage().startsWith("TSV was not successfully initialized: "));
+            assertTrue(ex.getCause() instanceof BridgeExporterNonRetryableException);
+            assertEquals(ex.getCause().getMessage(), "Table has deleted and/or modified columns");
         }
     }
 

--- a/src/test/java/org/sagebionetworks/bridge/exporter/worker/TsvInfoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/worker/TsvInfoTest.java
@@ -7,7 +7,6 @@ import static org.testng.Assert.*;
 
 import java.io.File;
 import java.io.PrintWriter;
-import java.util.ArrayList;
 import java.util.List;
 
 import com.google.common.collect.ImmutableList;
@@ -16,6 +15,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.exporter.exceptions.BridgeExporterException;
+import org.sagebionetworks.bridge.exporter.exceptions.BridgeExporterTsvException;
 
 public class TsvInfoTest {
     private static final List<String> COLUMN_NAME_LIST = ImmutableList.of("foo", "bar");
@@ -72,29 +72,35 @@ public class TsvInfoTest {
 
     @Test
     public void initError() {
+        Exception testEx = new Exception();
+        TsvInfo errorTsvInfo = new TsvInfo(testEx);
+
         try {
-            TsvInfo.INIT_ERROR_TSV_INFO.checkInitAndThrow();
+            errorTsvInfo.checkInitAndThrow();
             fail("expected exception");
         } catch (BridgeExporterException ex) {
-            // expected exception
+            assertTrue(ex instanceof BridgeExporterTsvException);
+            assertSame(ex.getCause(), testEx);
         }
 
         try {
-            TsvInfo.INIT_ERROR_TSV_INFO.writeRow(ImmutableMap.of());
+            errorTsvInfo.writeRow(ImmutableMap.of());
             fail("expected exception");
         } catch (BridgeExporterException ex) {
-            // expected exception
+            assertTrue(ex instanceof BridgeExporterTsvException);
+            assertSame(ex.getCause(), testEx);
         }
 
         try {
-            TsvInfo.INIT_ERROR_TSV_INFO.flushAndCloseWriter();
+            errorTsvInfo.flushAndCloseWriter();
             fail("expected exception");
         } catch (BridgeExporterException ex) {
-            // expected exception
+            assertTrue(ex instanceof BridgeExporterTsvException);
+            assertSame(ex.getCause(), testEx);
         }
 
-        assertNull(TsvInfo.INIT_ERROR_TSV_INFO.getFile());
-        assertEquals(TsvInfo.INIT_ERROR_TSV_INFO.getLineCount(), 0);
-        assertEquals(TsvInfo.INIT_ERROR_TSV_INFO.getRecordIds().size(), 0);
+        assertNull(errorTsvInfo.getFile());
+        assertEquals(errorTsvInfo.getLineCount(), 0);
+        assertEquals(errorTsvInfo.getRecordIds().size(), 0);
     }
 }


### PR DESCRIPTION
This change improves BridgeEX's redrive logic. First, it differentiates between retryable and non-retryable errors, so BridgeEX won't be stuck in a loop retrying exports that are doomed to failure.

Non-retryable errors include:
* 4XX errors from Bridge Server
* JSON parse exceptions
* mismatched schema errors

Second, when a TSV fails to initiate, BridgeEX now only redrives the table and not the records, to prevent a "double redrive". (Note this doesn't fix the general case, where a record fails and its table also fails. These tend to be fairly rare. The fix would also be more complicated, and likely outside the scope of a short-term DevOps fix.)

These fixes are in response to DevOps issues resulting from the mythoughts schema incident and the recordExportStatus incident. See also https://sagebionetworks.jira.com/browse/BRIDGE-1633

Testing done:
* mvn verify (unit tests, findbugs, jacoco test coverage)
* manual tests

Manual test cases:
* successful export
* modified schema error (mythoughts schema case)
* bad BridgePF URL (record export status case)
* inject errors (retryable/non-retryble x record/table)