### PR TITLE
BridgeEX misc DevOps fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <dependency>
             <groupId>org.sagebionetworks</groupId>
             <artifactId>bridge-base</artifactId>
-            <version>2.7</version>
+            <version>2.7.3</version>
         </dependency>
         <dependency>
             <groupId>org.sagebionetworks.bridge</groupId>
@@ -126,7 +126,7 @@
         <dependency>
             <groupId>org.sagebionetworks</groupId>
             <artifactId>BridgeTestUtils</artifactId>
-            <version>1.0</version>
+            <version>1.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/org/sagebionetworks/bridge/exporter/handler/SynapseExportHandlerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/handler/SynapseExportHandlerTest.java
@@ -39,7 +39,6 @@ import org.sagebionetworks.bridge.rest.model.UploadFieldType;
 import org.sagebionetworks.bridge.rest.model.UploadSchema;
 import org.sagebionetworks.bridge.schema.UploadSchemaKey;
 
-import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.notNull;
@@ -54,6 +53,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 public class SynapseExportHandlerTest {
     // Constants needed to create metadata (phone info, app version)

--- a/src/test/java/org/sagebionetworks/bridge/exporter/synapse/SynapseHelperTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/synapse/SynapseHelperTest.java
@@ -25,7 +25,6 @@ import org.sagebionetworks.repo.model.AccessControlList;
 import org.sagebionetworks.repo.model.ResourceAccess;
 import org.sagebionetworks.repo.model.file.FileHandle;
 import org.sagebionetworks.repo.model.file.S3FileHandle;
-import org.sagebionetworks.repo.model.file.UploadDestination;
 import org.sagebionetworks.repo.model.status.StackStatus;
 import org.sagebionetworks.repo.model.status.StatusEnum;
 import org.sagebionetworks.repo.model.table.ColumnModel;
@@ -117,13 +116,9 @@ public class SynapseHelperTest {
         // mock Synapse Client
         SynapseClient mockSynapseClient = mock(SynapseClient.class);
 
-        UploadDestination mockUploadDestination = mock(UploadDestination.class);
-        when(mockUploadDestination.getStorageLocationId()).thenReturn(1234L);
-        when(mockSynapseClient.getDefaultUploadDestination("project-id")).thenReturn(mockUploadDestination);
-
         File mockFile = mock(File.class);
         S3FileHandle mockFileHandle = mock(S3FileHandle.class);
-        when(mockSynapseClient.multipartUpload(mockFile, 1234L, null, null)).thenReturn(mockFileHandle);
+        when(mockSynapseClient.multipartUpload(mockFile, null, null, null)).thenReturn(mockFileHandle);
 
         SynapseHelper synapseHelper = new SynapseHelper();
         synapseHelper.setSynapseClient(mockSynapseClient);


### PR DESCRIPTION
A few fixes in response to recent DevOps incidents.
* Remove getUploadDestination() call when creating a Synapse file handle - This is generating unnecessary traffic to Synapse and is a throttling risk.
* Filter out empty attachments - Empty attachments fail and cause an infinite retry loop. This change filters out empty attachments.

Testing done:
* mvn verify (unit tests, findbugs, jacoco test coverage)
* manually tested empty attachment case and normal export with normal attachments

Pre-reqs:
* https://github.com/Sage-Bionetworks/bridge-base/pull/29
* https://github.com/Sage-Bionetworks/BridgeTestUtils/pull/4