### PR TITLE
Rate Limiting and Metrics for Synapse requests

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/exporter/handler/HealthDataExportHandler.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/handler/HealthDataExportHandler.java
@@ -176,10 +176,11 @@ public class HealthDataExportHandler extends SynapseExportHandler {
         ExportWorkerManager manager = getManager();
         String synapseProjectId = manager.getSynapseProjectIdForStudyAndTask(getStudyId(), task);
         String recordId = subtask.getRecordId();
+        Metrics metrics = task.getMetrics();
 
         // schema-specific columns
         Map<String, String> rowValueMap = new HashMap<>();
-        List<UploadFieldDefinition> fieldDefList = getSchemaFieldDefList(task.getMetrics());
+        List<UploadFieldDefinition> fieldDefList = getSchemaFieldDefList(metrics);
         for (UploadFieldDefinition oneFieldDef : fieldDefList) {
             String oneFieldName = oneFieldDef.getName();
             UploadFieldType bridgeType = oneFieldDef.getType();
@@ -209,8 +210,8 @@ public class HealthDataExportHandler extends SynapseExportHandler {
                 Map<String, String> serializedTimestampFields = serializeTimestamp(recordId, oneFieldName, valueNode);
                 rowValueMap.putAll(serializedTimestampFields);
             } else {
-                String value = manager.getSynapseHelper().serializeToSynapseType(task.getTmpDir(), synapseProjectId,
-                        recordId, oneFieldDef, valueNode);
+                String value = manager.getSynapseHelper().serializeToSynapseType(metrics, task.getTmpDir(),
+                        synapseProjectId, recordId, oneFieldDef, valueNode);
                 rowValueMap.put(oneFieldName, value);
             }
         }

--- a/src/main/java/org/sagebionetworks/bridge/exporter/record/BridgeExporterRecordProcessor.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/record/BridgeExporterRecordProcessor.java
@@ -190,13 +190,25 @@ public class BridgeExporterRecordProcessor {
             }
 
             workerManager.endOfStream(task);
+
+            // We made it to the end. Set the success flag on the task.
+            setTaskSuccess(task);
         } finally {
-            LOG.info("Finished processing request in " + stopwatch.elapsed(TimeUnit.SECONDS) + " seconds, " +
-                    request.toString());
+            long elapsedTime = stopwatch.elapsed(TimeUnit.SECONDS);
+            if (task.isSuccess()) {
+                LOG.info("Finished processing request in " + elapsedTime + " seconds, " + request.toString());
+            } else {
+                LOG.error("Error processing request; elapsed time " + elapsedTime + " seconds, " + request.toString());
+            }
             metricsHelper.publishMetrics(metrics);
         }
 
         // cleanup
         fileHelper.deleteDir(tmpDir);
+    }
+
+    // Helper method that we can spy and verify that we're setting the task success properly.
+    void setTaskSuccess(ExportTask task) {
+        task.setSuccess(true);
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/exporter/worker/ExportTask.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/worker/ExportTask.java
@@ -120,6 +120,7 @@ public class ExportTask {
     private final Map<UploadSchemaKey, TsvInfo> healthDataTsvInfoBySchema = new HashMap<>();
     private final Set<String> studyIdSet = new HashSet<>();
     private final Queue<ExportSubtaskFuture> subtaskFutureQueue = new LinkedList<>();
+    private boolean success = false;
 
     /** Gets the appVersion table TSV info for the specified study. */
     public TsvInfo getAppVersionTsvInfoForStudy(String studyId) {
@@ -159,5 +160,15 @@ public class ExportTask {
     /** Gets the set of study IDs that were seen by this task. Used to do per-study post-processing. */
     public Set<String> getStudyIdSet() {
         return studyIdSet;
+    }
+
+    /** True if the task completed successfully. False if the task failed or otherwise did not complete. */
+    public boolean isSuccess() {
+        return success;
+    }
+
+    /** Sets the success status on the task. */
+    public void setSuccess(boolean success) {
+        this.success = success;
     }
 }

--- a/src/main/resources/BridgeExporter.conf
+++ b/src/main/resources/BridgeExporter.conf
@@ -16,7 +16,8 @@ record.loop.delay.millis=30
 record.loop.progress.report.period=1000
 synapse.async.interval.millis = 1000
 synapse.async.timeout.loops = 300
-threadpool.worker.count=16
+synapse.rate.limit.per.second = 10
+threadpool.worker.count=4
 time.zone.name=America/Los_Angeles
 worker.manager.progress.report.period=250
 

--- a/src/test/java/org/sagebionetworks/bridge/exporter/handler/HealthDataExportHandlerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/handler/HealthDataExportHandlerTest.java
@@ -253,7 +253,7 @@ public class HealthDataExportHandlerTest {
 
         // mock serializeToSynapseType() - We actually call through to the real method. Don't need to mock
         // uploadFromS3ToSynapseFileHandle() because we don't have file handles this time.
-        when(mockSynapseHelper.serializeToSynapseType(any(), any(), any(), any(), any())).thenCallRealMethod();
+        when(mockSynapseHelper.serializeToSynapseType(any(), any(), any(), any(), any(), any())).thenCallRealMethod();
 
         // mock upload the TSV and capture the upload
         tsvBytes = null;

--- a/src/test/java/org/sagebionetworks/bridge/exporter/handler/SynapseExportHandlerNewTableTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/handler/SynapseExportHandlerNewTableTest.java
@@ -199,7 +199,7 @@ public class SynapseExportHandlerNewTableTest {
 
         // mock serializeToSynapseType() - We actually call through to the real method. Don't need to mock
         // uploadFromS3ToSynapseFileHandle() because we don't have file handles this time.
-        when(mockSynapseHelper.serializeToSynapseType(any(), any(), any(), any(), any())).thenCallRealMethod();
+        when(mockSynapseHelper.serializeToSynapseType(any(), any(), any(), any(), any(), any())).thenCallRealMethod();
 
         // make subtask
         String recordJsonText = "{\n" +

--- a/src/test/java/org/sagebionetworks/bridge/exporter/handler/SynapseExportHandlerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/handler/SynapseExportHandlerTest.java
@@ -360,7 +360,7 @@ public class SynapseExportHandlerTest {
 
         // mock serializeToSynapseType() - We actually call through to the real method, but we mock out the underlying
         // uploadFromS3ToSynapseFileHandle() to avoid hitting real back-ends.
-        when(mockSynapseHelper.serializeToSynapseType(any(), any(), any(), any(), any())).thenCallRealMethod();
+        when(mockSynapseHelper.serializeToSynapseType(any(), any(), any(), any(), any(), any())).thenCallRealMethod();
 
         UploadFieldDefinition freeformAttachmentFieldDef = new UploadFieldDefinition().name(FREEFORM_FIELD_NAME)
                 .type(UploadFieldType.ATTACHMENT_V2);

--- a/src/test/java/org/sagebionetworks/bridge/exporter/record/BridgeExporterRecordProcessorSynapseWritableTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/record/BridgeExporterRecordProcessorSynapseWritableTest.java
@@ -1,0 +1,58 @@
+package org.sagebionetworks.bridge.exporter.record;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.joda.time.LocalDate;
+import org.sagebionetworks.client.exceptions.SynapseClientException;
+import org.sagebionetworks.schema.adapter.JSONObjectAdapterException;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import org.sagebionetworks.bridge.exporter.exceptions.SynapseUnavailableException;
+import org.sagebionetworks.bridge.exporter.request.BridgeExporterRequest;
+import org.sagebionetworks.bridge.exporter.synapse.SynapseHelper;
+
+@SuppressWarnings("unchecked")
+public class BridgeExporterRecordProcessorSynapseWritableTest {
+    private static final BridgeExporterRequest REQUEST = new BridgeExporterRequest.Builder()
+            .withDate(LocalDate.parse("2015-11-04")).withTag("unit-test-tag").build();
+
+    @Test(expectedExceptions = SynapseUnavailableException.class, expectedExceptionsMessageRegExp =
+            "Synapse not in writable state")
+    public void synapseNotWritable() throws Exception {
+        // mock Synapse helper
+        SynapseHelper mockSynapseHelper = mock(SynapseHelper.class);
+        when(mockSynapseHelper.isSynapseWritable()).thenReturn(false);
+
+        // set up record processor
+        BridgeExporterRecordProcessor recordProcessor = new BridgeExporterRecordProcessor();
+        recordProcessor.setSynapseHelper(mockSynapseHelper);
+
+        // execute (should throw)
+        recordProcessor.processRecordsForRequest(REQUEST);
+    }
+
+    @DataProvider(name = "synapseWritableExceptionProvider")
+    public Object[][] synapseWritableExceptionProvider() {
+        return new Object[][] {
+                { JSONObjectAdapterException.class },
+                { SynapseClientException.class },
+        };
+    }
+
+    @Test(dataProvider = "synapseWritableExceptionProvider", expectedExceptions = SynapseUnavailableException.class,
+            expectedExceptionsMessageRegExp = "Error calling Synapse.*")
+    public void synapseWritableException(Class<? extends Throwable> exceptionClass) throws Exception {
+        // mock Synapse helper
+        SynapseHelper mockSynapseHelper = mock(SynapseHelper.class);
+        when(mockSynapseHelper.isSynapseWritable()).thenThrow(exceptionClass);
+
+        // set up record processor
+        BridgeExporterRecordProcessor recordProcessor = new BridgeExporterRecordProcessor();
+        recordProcessor.setSynapseHelper(mockSynapseHelper);
+
+        // execute (should throw)
+        recordProcessor.processRecordsForRequest(REQUEST);
+    }
+}

--- a/src/test/java/org/sagebionetworks/bridge/exporter/record/BridgeExporterRecordProcessorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/record/BridgeExporterRecordProcessorTest.java
@@ -4,12 +4,15 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.same;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 import java.io.IOException;
 import java.util.List;
@@ -19,13 +22,11 @@ import com.amazonaws.services.dynamodbv2.document.Table;
 import com.google.common.collect.ImmutableList;
 import org.joda.time.LocalDate;
 import org.mockito.ArgumentCaptor;
-import org.sagebionetworks.client.exceptions.SynapseClientException;
-import org.sagebionetworks.schema.adapter.JSONObjectAdapterException;
-import org.testng.annotations.DataProvider;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.config.Config;
-import org.sagebionetworks.bridge.exporter.exceptions.SynapseUnavailableException;
+import org.sagebionetworks.bridge.exporter.exceptions.RestartBridgeExporterException;
 import org.sagebionetworks.bridge.exporter.metrics.Metrics;
 import org.sagebionetworks.bridge.exporter.metrics.MetricsHelper;
 import org.sagebionetworks.bridge.exporter.request.BridgeExporterRequest;
@@ -40,6 +41,48 @@ public class BridgeExporterRecordProcessorTest {
     private static final BridgeExporterRequest REQUEST = new BridgeExporterRequest.Builder()
             .withDate(LocalDate.parse("2015-11-04")).withTag("unit-test-tag").build();
 
+    private Table mockDdbRecordTable;
+    private InMemoryFileHelper mockFileHelper;
+    private ExportWorkerManager mockManager;
+    private MetricsHelper mockMetricsHelper;
+    private RecordFilterHelper mockRecordFilterHelper;
+    private RecordIdSourceFactory mockRecordIdFactory;
+    private BridgeExporterRecordProcessor recordProcessor;
+
+    @BeforeMethod
+    public void before() throws Exception {
+        // mock Config - For branch coverage, make progress report period 2
+        Config mockConfig = mock(Config.class);
+        when(mockConfig.getInt(BridgeExporterRecordProcessor.CONFIG_KEY_RECORD_LOOP_DELAY_MILLIS)).thenReturn(0);
+        when(mockConfig.getInt(BridgeExporterRecordProcessor.CONFIG_KEY_RECORD_LOOP_PROGRESS_REPORT_PERIOD))
+                .thenReturn(2);
+        when(mockConfig.get(BridgeExporterUtil.CONFIG_KEY_TIME_ZONE_NAME))
+                .thenReturn("America/Los_Angeles");
+
+        // mock Synapse Helper - For this test, Synapse is up and writable.
+        SynapseHelper mockSynapseHelper = mock(SynapseHelper.class);
+        when(mockSynapseHelper.isSynapseWritable()).thenReturn(true);
+
+        // mocks
+        mockDdbRecordTable = mock(Table.class);
+        mockFileHelper = new InMemoryFileHelper();
+        mockManager = mock(ExportWorkerManager.class);
+        mockMetricsHelper = mock(MetricsHelper.class);
+        mockRecordFilterHelper = mock(RecordFilterHelper.class);
+        mockRecordIdFactory = mock(RecordIdSourceFactory.class);
+
+        // set up record processor
+        recordProcessor = spy(new BridgeExporterRecordProcessor());
+        recordProcessor.setConfig(mockConfig);
+        recordProcessor.setDdbRecordTable(mockDdbRecordTable);
+        recordProcessor.setFileHelper(mockFileHelper);
+        recordProcessor.setMetricsHelper(mockMetricsHelper);
+        recordProcessor.setRecordFilterHelper(mockRecordFilterHelper);
+        recordProcessor.setRecordIdSourceFactory(mockRecordIdFactory);
+        recordProcessor.setSynapseHelper(mockSynapseHelper);
+        recordProcessor.setWorkerManager(mockManager);
+    }
+
     @Test
     public void test() throws Exception {
         // 5 records:
@@ -49,14 +92,6 @@ public class BridgeExporterRecordProcessorTest {
         // * error
         // * success again
 
-        // mock Config - For branch coverage, make progress report period 2
-        Config mockConfig = mock(Config.class);
-        when(mockConfig.getInt(BridgeExporterRecordProcessor.CONFIG_KEY_RECORD_LOOP_DELAY_MILLIS)).thenReturn(0);
-        when(mockConfig.getInt(BridgeExporterRecordProcessor.CONFIG_KEY_RECORD_LOOP_PROGRESS_REPORT_PERIOD))
-                .thenReturn(2);
-        when(mockConfig.get(BridgeExporterUtil.CONFIG_KEY_TIME_ZONE_NAME))
-                .thenReturn("America/Los_Angeles");
-
         // mock DDB record table - We don't look inside any of these records, so for the purposes of this test, just
         // make dummy DDB record items with no content.
         Item dummySuccessRecord1 = new Item();
@@ -64,21 +99,13 @@ public class BridgeExporterRecordProcessorTest {
         Item dummyErrorRecord = new Item();
         Item dummySuccessRecord2 = new Item();
 
-        Table mockDdbRecordTable = mock(Table.class);
         when(mockDdbRecordTable.getItem("id", "success-record-1")).thenReturn(dummySuccessRecord1);
         when(mockDdbRecordTable.getItem("id", "filtered-record")).thenReturn(dummyFilteredRecord);
         when(mockDdbRecordTable.getItem("id", "error-record")).thenReturn(dummyErrorRecord);
         when(mockDdbRecordTable.getItem("id", "success-record-2")).thenReturn(dummySuccessRecord2);
 
-        // mock File Helper
-        InMemoryFileHelper mockFileHelper = new InMemoryFileHelper();
-
-        // mock Metrics Helper
-        MetricsHelper mockMetricsHelper = mock(MetricsHelper.class);
-
         // mock record filter helper - Only mock the filtered record. All the others will return false by default in
         // Mockito.
-        RecordFilterHelper mockRecordFilterHelper = mock(RecordFilterHelper.class);
         ArgumentCaptor<Metrics> recordFilterMetricsCaptor = ArgumentCaptor.forClass(Metrics.class);
         when(mockRecordFilterHelper.shouldExcludeRecord(recordFilterMetricsCaptor.capture(), same(REQUEST),
                 same(dummyFilteredRecord))).thenReturn(true);
@@ -86,29 +113,11 @@ public class BridgeExporterRecordProcessorTest {
         // mock record ID factory
         List<String> recordIdList = ImmutableList.of("success-record-1", "filtered-record", "missing-record",
                 "error-record", "success-record-2");
-
-        RecordIdSourceFactory mockRecordIdFactory = mock(RecordIdSourceFactory.class);
         when(mockRecordIdFactory.getRecordSourceForRequest(REQUEST)).thenReturn(recordIdList);
 
-        // mock Synapse Helper - For this test, Synapse is up and writable.
-        SynapseHelper mockSynapseHelper = mock(SynapseHelper.class);
-        when(mockSynapseHelper.isSynapseWritable()).thenReturn(true);
-
         // mock export worker manager - Only mock error record. The others will just no-op by default in Mockito.
-        ExportWorkerManager mockManager = mock(ExportWorkerManager.class);
         doThrow(IOException.class).when(mockManager).addSubtaskForRecord(any(ExportTask.class),
                 same(dummyErrorRecord));
-
-        // set up record processor
-        BridgeExporterRecordProcessor recordProcessor = new BridgeExporterRecordProcessor();
-        recordProcessor.setConfig(mockConfig);
-        recordProcessor.setDdbRecordTable(mockDdbRecordTable);
-        recordProcessor.setFileHelper(mockFileHelper);
-        recordProcessor.setMetricsHelper(mockMetricsHelper);
-        recordProcessor.setRecordFilterHelper(mockRecordFilterHelper);
-        recordProcessor.setRecordIdSourceFactory(mockRecordIdFactory);
-        recordProcessor.setSynapseHelper(mockSynapseHelper);
-        recordProcessor.setWorkerManager(mockManager);
 
         // execute
         recordProcessor.processRecordsForRequest(REQUEST);
@@ -143,6 +152,9 @@ public class BridgeExporterRecordProcessorTest {
         assertSame(managerTaskArgList.get(2), managerTaskArgList.get(0));
         assertSame(managerTaskArgList.get(3), managerTaskArgList.get(0));
 
+        // verify that we marked the task as success
+        verify(recordProcessor).setTaskSuccess(any());
+
         // validate record filter metrics is the same as the one passed to the metrics helper
         Metrics recordFilterMetrics = recordFilterMetricsCaptor.getValue();
         assertSame(recordFilterMetrics, metricsHelperArgList.get(0));
@@ -151,41 +163,26 @@ public class BridgeExporterRecordProcessorTest {
         assertTrue(mockFileHelper.isEmpty());
     }
 
-    @Test(expectedExceptions = SynapseUnavailableException.class, expectedExceptionsMessageRegExp =
-            "Synapse not in writable state")
-    public void synapseNotWritable() throws Exception {
-        // mock Synapse helper
-        SynapseHelper mockSynapseHelper = mock(SynapseHelper.class);
-        when(mockSynapseHelper.isSynapseWritable()).thenReturn(false);
+    @Test
+    public void endOfStreamThrows() throws Exception {
+        // Only need 1 test record this time.
 
-        // set up record processor
-        BridgeExporterRecordProcessor recordProcessor = new BridgeExporterRecordProcessor();
-        recordProcessor.setSynapseHelper(mockSynapseHelper);
+        // mock DDB record table and record ID factory
+        when(mockDdbRecordTable.getItem("id", "dummy-record")).thenReturn(new Item());
+        when(mockRecordIdFactory.getRecordSourceForRequest(REQUEST)).thenReturn(ImmutableList.of("dummy-record"));
 
-        // execute (should throw)
-        recordProcessor.processRecordsForRequest(REQUEST);
-    }
+        // ExportWorkerManager throws in endOfStream()
+        doThrow(RestartBridgeExporterException.class).when(mockManager).endOfStream(any());
 
-    @DataProvider(name = "synapseWritableExceptionProvider")
-    public Object[][] synapseWritableExceptionProvider() {
-        return new Object[][] {
-                { JSONObjectAdapterException.class },
-                { SynapseClientException.class },
-        };
-    }
+        // execute (this will throw)
+        try {
+            recordProcessor.processRecordsForRequest(REQUEST);
+            fail("expected exception");
+        } catch (RestartBridgeExporterException ex) {
+            // expected exception
+        }
 
-    @Test(dataProvider = "synapseWritableExceptionProvider", expectedExceptions = SynapseUnavailableException.class,
-            expectedExceptionsMessageRegExp = "Error calling Synapse.*")
-    public void synapseWritableException(Class<? extends Throwable> exceptionClass) throws Exception {
-        // mock Synapse helper
-        SynapseHelper mockSynapseHelper = mock(SynapseHelper.class);
-        when(mockSynapseHelper.isSynapseWritable()).thenThrow(exceptionClass);
-
-        // set up record processor
-        BridgeExporterRecordProcessor recordProcessor = new BridgeExporterRecordProcessor();
-        recordProcessor.setSynapseHelper(mockSynapseHelper);
-
-        // execute (should throw)
-        recordProcessor.processRecordsForRequest(REQUEST);
+        // verify that we're NOT marking the task as success
+        verify(recordProcessor, never()).setTaskSuccess(any());
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/exporter/synapse/SynapseHelperUploadAttachmentTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/synapse/SynapseHelperUploadAttachmentTest.java
@@ -247,6 +247,10 @@ public class SynapseHelperUploadAttachmentTest {
     private static Config mockConfig() {
         Config mockConfig = mock(Config.class);
         when(mockConfig.get(BridgeExporterUtil.CONFIG_KEY_ATTACHMENT_S3_BUCKET)).thenReturn(TEST_ATTACHMENTS_BUCKET);
+
+        // Set a very high number for rate limiting, since we don't want the rate limiter to interfere with our tests.
+        when(mockConfig.getInt(SynapseHelper.CONFIG_KEY_SYNAPSE_RATE_LIMIT_PER_SECOND)).thenReturn(1000);
+
         return mockConfig;
     }
 

--- a/src/test/java/org/sagebionetworks/bridge/exporter/synapse/SynapseHelperUploadTsvToTableTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/synapse/SynapseHelperUploadTsvToTableTest.java
@@ -45,6 +45,8 @@ public class SynapseHelperUploadTsvToTableTest {
         Config config = mock(Config.class);
         when(config.getInt(SynapseHelper.CONFIG_KEY_SYNAPSE_ASYNC_INTERVAL_MILLIS)).thenReturn(0);
         when(config.getInt(SynapseHelper.CONFIG_KEY_SYNAPSE_ASYNC_TIMEOUT_LOOPS)).thenReturn(2);
+        // Set a very high number for rate limiting, since we don't want the rate limiter to interfere with our tests.
+        when(config.getInt(SynapseHelper.CONFIG_KEY_SYNAPSE_RATE_LIMIT_PER_SECOND)).thenReturn(1000);
 
         // mock Synapse Client - Mock everything except uploadCsvToTableAsyncGet(), which depends on the test.
         mockSynapseClient = mock(SynapseClient.class);


### PR DESCRIPTION
A few changes in response to Synapse Throttling:
* Add RateLimiter to SynapseHelper.
* Default config is now 4 threads.
* Logging now indicates whether request succeeded or failed.
* Count the number of file handles.

This also does a few test refactors.

Testing done:
* mvn verify (unit tests, findbugs, jacoco test coverage)
* manually tested successful export with attachment
* injected error, manually verified log reports error