### PR TITLE
Limit Redrives

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/exporter/request/BridgeExporterRequest.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/request/BridgeExporterRequest.java
@@ -27,6 +27,7 @@ public class BridgeExporterRequest {
     private final DateTime endDateTime;
     private final String exporterDdbPrefixOverride;
     private final String recordIdS3Override;
+    private final int redriveCount;
     private final BridgeExporterSharingMode sharingMode;
     private final DateTime startDateTime;
     private final Set<String> studyWhitelist;
@@ -36,13 +37,14 @@ public class BridgeExporterRequest {
 
     /** Private constructor. To build, go through the builder. */
     private BridgeExporterRequest(LocalDate date, DateTime endDateTime, String exporterDdbPrefixOverride,
-            String recordIdS3Override, BridgeExporterSharingMode sharingMode, DateTime startDateTime,
+            String recordIdS3Override, int redriveCount, BridgeExporterSharingMode sharingMode, DateTime startDateTime,
             Set<String> studyWhitelist, Map<String, String> synapseProjectOverrideMap,
             Set<UploadSchemaKey> tableWhitelist, String tag) {
         this.date = date;
         this.endDateTime = endDateTime;
         this.exporterDdbPrefixOverride = exporterDdbPrefixOverride;
         this.recordIdS3Override = recordIdS3Override;
+        this.redriveCount = redriveCount;
         this.sharingMode = sharingMode;
         this.startDateTime = startDateTime;
         this.studyWhitelist = studyWhitelist;
@@ -85,6 +87,14 @@ public class BridgeExporterRequest {
      */
     public String getRecordIdS3Override() {
         return recordIdS3Override;
+    }
+
+    /**
+     * The number of times this request has been redriven. Zero if this is the first request. 1 if this is the first
+     * redrive. And so forth.
+     */
+    public int getRedriveCount() {
+        return redriveCount;
     }
 
     /**
@@ -152,6 +162,7 @@ public class BridgeExporterRequest {
                 Objects.equals(endDateTime, that.endDateTime) &&
                 Objects.equals(exporterDdbPrefixOverride, that.exporterDdbPrefixOverride) &&
                 Objects.equals(recordIdS3Override, that.recordIdS3Override) &&
+                redriveCount == that.redriveCount &&
                 sharingMode == that.sharingMode &&
                 Objects.equals(startDateTime, that.startDateTime) &&
                 Objects.equals(studyWhitelist, that.studyWhitelist) &&
@@ -162,7 +173,7 @@ public class BridgeExporterRequest {
 
     @Override
     public final int hashCode() {
-        return Objects.hash(date, endDateTime, exporterDdbPrefixOverride, recordIdS3Override, sharingMode,
+        return Objects.hash(date, endDateTime, exporterDdbPrefixOverride, recordIdS3Override, redriveCount, sharingMode,
                 startDateTime, studyWhitelist, synapseProjectOverrideMap, tableWhitelist, tag);
     }
 
@@ -189,6 +200,10 @@ public class BridgeExporterRequest {
             stringBuilder.append(recordIdS3Override);
         }
 
+        // Include redriveCount, since this is helpful for logging and diagnostics.
+        stringBuilder.append(", redriveCount=");
+        stringBuilder.append(redriveCount);
+
         // Always include tag.
         stringBuilder.append(", tag=");
         stringBuilder.append(tag);
@@ -202,6 +217,7 @@ public class BridgeExporterRequest {
         private DateTime endDateTime;
         private String exporterDdbPrefixOverride;
         private String recordIdS3Override;
+        private int redriveCount;
         private BridgeExporterSharingMode sharingMode;
         private DateTime startDateTime;
         private Set<String> studyWhitelist;
@@ -216,6 +232,7 @@ public class BridgeExporterRequest {
             endDateTime = other.endDateTime;
             exporterDdbPrefixOverride = other.exporterDdbPrefixOverride;
             recordIdS3Override = other.recordIdS3Override;
+            redriveCount = other.redriveCount;
             sharingMode = other.sharingMode;
             startDateTime = other.startDateTime;
             studyWhitelist = other.studyWhitelist;
@@ -248,6 +265,12 @@ public class BridgeExporterRequest {
         /** @see BridgeExporterRequest#getRecordIdS3Override */
         public Builder withRecordIdS3Override(String recordIdS3Override) {
             this.recordIdS3Override = recordIdS3Override;
+            return this;
+        }
+
+        /** @see BridgeExporterRequest#getRedriveCount */
+        public Builder withRedriveCount(int redriveCount) {
+            this.redriveCount = redriveCount;
             return this;
         }
 
@@ -367,7 +390,8 @@ public class BridgeExporterRequest {
             }
 
             return new BridgeExporterRequest(date, endDateTime, exporterDdbPrefixOverride, recordIdS3Override,
-                    sharingMode, startDateTime, studyWhitelist, synapseProjectOverrideMap, tableWhitelist, tag);
+                    redriveCount, sharingMode, startDateTime, studyWhitelist, synapseProjectOverrideMap,
+                    tableWhitelist, tag);
         }
     }
 }

--- a/src/main/resources/BridgeExporter.conf
+++ b/src/main/resources/BridgeExporter.conf
@@ -43,3 +43,6 @@ local.record.id.override.bucket=org-sagebridge-exporter-recordids-local
 dev.record.id.override.bucket=org-sagebridge-exporter-recordids-develop
 uat.record.id.override.bucket=org-sagebridge-exporter-recordids-uat
 prod.record.id.override.bucket=org-sagebridge-exporter-recordids-prod
+
+redrive.max.count=2
+prod.redrive.max.count=5

--- a/src/test/java/org/sagebionetworks/bridge/exporter/request/BridgeExporterRequestTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/request/BridgeExporterRequestTest.java
@@ -47,6 +47,9 @@ public class BridgeExporterRequestTest {
         assertEquals(request.getDate(), TEST_DATE);
         assertEquals(request.getSharingMode(), BridgeExporterSharingMode.SHARED);
 
+        // test toString
+        assertEquals(request.toString(), "date=" + TEST_DATE + ", redriveCount=0, tag=null");
+
         // test copy
         BridgeExporterRequest copy = new BridgeExporterRequest.Builder().copyOf(request).build();
         assertEquals(copy, request);
@@ -61,6 +64,10 @@ public class BridgeExporterRequestTest {
         assertEquals(request.getSharingMode(), BridgeExporterSharingMode.SHARED);
         assertEquals(request.getStudyWhitelist(), STUDY_WHITELIST);
 
+        // test toString
+        assertEquals(request.toString(), "startDateTime=" + START_DATE_TIME + ", endDateTime=" + END_DATE_TIME
+                + ", redriveCount=0, tag=null");
+
         // test copy
         BridgeExporterRequest copy = new BridgeExporterRequest.Builder().copyOf(request).build();
         assertEquals(copy, request);
@@ -72,6 +79,9 @@ public class BridgeExporterRequestTest {
                 .withRecordIdS3Override(TEST_RECORD_OVERRIDE).build();
         assertEquals(request.getRecordIdS3Override(), TEST_RECORD_OVERRIDE);
         assertEquals(request.getSharingMode(), BridgeExporterSharingMode.SHARED);
+
+        // test toString
+        assertEquals(request.toString(), "recordIdS3Override=" + TEST_RECORD_OVERRIDE + ", redriveCount=0, tag=null");
 
         // test copy
         BridgeExporterRequest copy = new BridgeExporterRequest.Builder().copyOf(request).build();
@@ -96,7 +106,7 @@ public class BridgeExporterRequestTest {
 
         // make request
         BridgeExporterRequest request = new BridgeExporterRequest.Builder().withDate(TEST_DATE)
-                .withExporterDdbPrefixOverride(TEST_DDB_PREFIX_OVERRIDE)
+                .withExporterDdbPrefixOverride(TEST_DDB_PREFIX_OVERRIDE).withRedriveCount(1)
                 .withSharingMode(BridgeExporterSharingMode.PUBLIC_ONLY).withStudyWhitelist(originalStudyWhitelist)
                 .withSynapseProjectOverrideMap(originalProjectOverrideMap).withTableWhitelist(originalTableWhitelist)
                 .withTag(TEST_TAG).build();
@@ -105,6 +115,7 @@ public class BridgeExporterRequestTest {
         assertEquals(request.getDate(), TEST_DATE);
         assertEquals(request.getExporterDdbPrefixOverride(), TEST_DDB_PREFIX_OVERRIDE);
         assertNull(request.getRecordIdS3Override());
+        assertEquals(request.getRedriveCount(), 1);
         assertEquals(request.getSharingMode(), BridgeExporterSharingMode.PUBLIC_ONLY);
         assertEquals(request.getStudyWhitelist(), originalStudyWhitelist);
         assertEquals(request.getSynapseProjectOverrideMap(), originalProjectOverrideMap);
@@ -120,6 +131,9 @@ public class BridgeExporterRequestTest {
 
         originalTableWhitelist.add(TEST_SCHEMA_KEY);
         assertFalse(request.getTableWhitelist().contains(TEST_SCHEMA_KEY));
+
+        // test toString
+        assertEquals(request.toString(), "date=" + TEST_DATE + ", redriveCount=1, tag=" + TEST_TAG);
 
         // test copy
         BridgeExporterRequest copy = new BridgeExporterRequest.Builder().copyOf(request).build();
@@ -306,6 +320,7 @@ public class BridgeExporterRequestTest {
         String jsonText = "{\n" +
                 "   \"exporterDdbPrefixOverride\":\"" + TEST_DDB_PREFIX_OVERRIDE + "\",\n" +
                 "   \"recordIdS3Override\":\"" + TEST_RECORD_OVERRIDE + "\",\n" +
+                "   \"redriveCount\":2,\n" +
                 "   \"sharingMode\":\"PUBLIC_ONLY\",\n" +
                 "   \"studyWhitelist\":[\"test-study\"],\n" +
                 "   \"synapseProjectOverrideMap\":{\n" +
@@ -324,6 +339,7 @@ public class BridgeExporterRequestTest {
         assertNull(request.getDate());
         assertEquals(request.getExporterDdbPrefixOverride(), TEST_DDB_PREFIX_OVERRIDE);
         assertEquals(request.getRecordIdS3Override(), TEST_RECORD_OVERRIDE);
+        assertEquals(request.getRedriveCount(), 2);
         assertEquals(request.getSharingMode(), BridgeExporterSharingMode.PUBLIC_ONLY);
         assertEquals(request.getStudyWhitelist(), ImmutableSet.of("test-study"));
         assertEquals(request.getSynapseProjectOverrideMap(), TEST_PROJECT_OVERRIDE_MAP);
@@ -335,6 +351,7 @@ public class BridgeExporterRequestTest {
         assertFalse(jsonNode.has("date"));
         assertEquals(jsonNode.get("exporterDdbPrefixOverride").textValue(), TEST_DDB_PREFIX_OVERRIDE);
         assertEquals(jsonNode.get("recordIdS3Override").textValue(), TEST_RECORD_OVERRIDE);
+        assertEquals(jsonNode.get("redriveCount").intValue(), 2);
         assertEquals(jsonNode.get("sharingMode").textValue(), BridgeExporterSharingMode.PUBLIC_ONLY.name());
         assertEquals(jsonNode.get("tag").textValue(), TEST_TAG);
 


### PR DESCRIPTION
Currently, BridgeEX can redrive infinitely. This is bad if for whatever reason, a particular record or table can't be redriven.

This change adds a redrive count to each request and limits the total number of redrives based on configuration.

Testing done:
* mvn verify (unit tests, findbugs, jacoco test coverage)
* manually tested successful export and tested injecting errors and verifying redrive max count logic

See also https://sagebionetworks.jira.com/browse/BRIDGE-1635