### PR TITLE
escape strings when exporting

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/exporter/util/BridgeExporterUtil.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/util/BridgeExporterUtil.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSetMultimap;
+import org.apache.commons.lang.StringEscapeUtils;
 import org.jsoup.Jsoup;
 import org.jsoup.safety.Whitelist;
 import org.sagebionetworks.bridge.exporter.synapse.ColumnDefinition;
@@ -168,7 +169,11 @@ public class BridgeExporterUtil {
         in = Jsoup.clean(in, Whitelist.none());
 
         // Remove tabs and newlines and carriage returns. This is needed to serialize strings into TSVs.
+        // We can't just escape these because Synapse will turn an escaped \n into n, and so forth.
         in = in.replaceAll("[\n\r\t]+", " ");
+
+        // Finally, escape the string. Unescaped quotes lead to weird stuff happening in Synapse.
+        in = StringEscapeUtils.escapeJava(in);
 
         // Check against max length, truncating and warning as necessary.
         if (maxLength != null && in.length() > maxLength) {

--- a/src/test/java/org/sagebionetworks/bridge/exporter/util/BridgeExporterUtilTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/util/BridgeExporterUtilTest.java
@@ -143,7 +143,7 @@ public class BridgeExporterUtilTest {
         };
     }
 
-    @Test
+    @Test(dataProvider = "sanitizeStringDataProvider")
     public void sanitizeString(String in, Integer maxLength, String expected) {
         assertEquals(BridgeExporterUtil.sanitizeString(in, "key", maxLength, "dummy-record"), expected);
     }


### PR DESCRIPTION
Unescaped strings cause weird things to happen. This change escapes the strings before exporting to Synapse.

Testing done:
* mvn verify (unit tests, findbugs, jacoco test coverage)
* manual test with quotes, already escaped quotes, and an inline json blob with strings