### PR TITLE
user-friendly Synapse table names

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/exporter/handler/AppVersionExportHandler.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/handler/AppVersionExportHandler.java
@@ -49,6 +49,11 @@ public class AppVersionExportHandler extends SynapseExportHandler {
     }
 
     @Override
+    protected String getSynapseTableName() {
+        return "Health Data Summary Table";
+    }
+
+    @Override
     protected List<ColumnModel> getSynapseTableColumnList(ExportTask task) {
         return APPVERSION_COLUMN_LIST;
     }

--- a/src/main/java/org/sagebionetworks/bridge/exporter/handler/HealthDataExportHandler.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/handler/HealthDataExportHandler.java
@@ -79,6 +79,11 @@ public class HealthDataExportHandler extends SynapseExportHandler {
     }
 
     @Override
+    protected String getSynapseTableName() {
+        return schemaKey.getSchemaId() + "-v" + schemaKey.getRevision();
+    }
+
+    @Override
     protected List<ColumnModel> getSynapseTableColumnList(ExportTask task) throws SchemaNotFoundException {
         List<UploadFieldDefinition> schemaFieldDefList = getSchemaFieldDefList(task.getMetrics());
         return getSynapseTableColumnListCached(schemaFieldDefList);

--- a/src/main/java/org/sagebionetworks/bridge/exporter/handler/SynapseExportHandler.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/handler/SynapseExportHandler.java
@@ -204,9 +204,8 @@ public abstract class SynapseExportHandler extends ExportHandler {
         long dataAccessTeamId = manager.getDataAccessTeamIdForStudy(getStudyId());
         long principalId = manager.getSynapsePrincipalId();
         String projectId = manager.getSynapseProjectIdForStudyAndTask(getStudyId(), task);
-        String tableName = getDdbTableKeyValue();
         String synapseTableId = synapseHelper.createTableWithColumnsAndAcls(columnDefList, dataAccessTeamId,
-                principalId, projectId, tableName);
+                principalId, projectId, getSynapseTableName());
 
         // write back to DDB table
         manager.setSynapseTableIdToDdb(task, getDdbTableName(), getDdbTableKeyName(), getDdbTableKeyValue(),
@@ -366,6 +365,12 @@ public abstract class SynapseExportHandler extends ExportHandler {
      * table, and since Synapse table names need to be unique, this is also used as the Synapse table name.
      */
     protected abstract String getDdbTableKeyValue();
+
+    /**
+     * Unique name for the table to be created in Synapse. This name may be different from the table key in DDB, as
+     * (for example) the table name doesn't need to include the study ID.
+     */
+    protected abstract String getSynapseTableName();
 
     /**
      * List of Synapse table column model objects, to be used to create both the column models and the Synapse table.

--- a/src/test/java/org/sagebionetworks/bridge/exporter/handler/SynapseExportHandlerNewTableTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/handler/SynapseExportHandlerNewTableTest.java
@@ -115,7 +115,7 @@ public class SynapseExportHandlerNewTableTest {
         when(mockSynapseHelper.createTableWithColumnsAndAcls(columnModelList,
                 SynapseExportHandlerTest.TEST_SYNAPSE_DATA_ACCESS_TEAM_ID,
                 SynapseExportHandlerTest.TEST_SYNAPSE_PRINCIPAL_ID, SynapseExportHandlerTest.TEST_SYNAPSE_PROJECT_ID,
-                handler.getDdbTableKeyValue())).thenReturn(SynapseExportHandlerTest.TEST_SYNAPSE_TABLE_ID);
+                handler.getSynapseTableName())).thenReturn(SynapseExportHandlerTest.TEST_SYNAPSE_TABLE_ID);
 
         // mock get column model list
         when(mockSynapseHelper.getColumnModelsForTableWithRetry(SynapseExportHandlerTest.TEST_SYNAPSE_TABLE_ID))

--- a/src/test/java/org/sagebionetworks/bridge/exporter/handler/TestSynapseHandler.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/handler/TestSynapseHandler.java
@@ -34,6 +34,11 @@ public class TestSynapseHandler extends SynapseExportHandler {
     }
 
     @Override
+    protected String getSynapseTableName() {
+        return "Test Synapse Table Name";
+    }
+
+    @Override
     protected List<ColumnModel> getSynapseTableColumnList(ExportTask task) {
         List<ColumnModel> columnList = new ArrayList<>();
 


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/BRIDGE-1942

Remove studyId from Synapse table names. Rename "appVersion" table to something more accurate "Health Data Summary Table".

Testing done:
* mvn verify (unit tests, FindBugs, Jacoco test coverage)
* integ tests
* deleted tables and manually verified new table names
* verified tables with new names still work with UserDataDownload