### PR TITLE
studyIdExcludedInExport flag

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/exporter/dynamo/DynamoHelper.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/dynamo/DynamoHelper.java
@@ -40,8 +40,9 @@ public class DynamoHelper {
 
     private static final String STUDY_INFO_KEY_DATA_ACCESS_TEAM = "synapseDataAccessTeamId";
     private static final String STUDY_INFO_KEY_PROJECT_ID = "synapseProjectId";
+    private static final String STUDY_DISABLE_EXPORT = "disableExport";
+    private static final String STUDY_INFO_KEY_STUDY_ID_EXCLUDED_IN_EXPORT = "studyIdExcludedInExport";
     private static final String STUDY_INFO_KEY_USES_CUSTOM_EXPORT_SCHEDULE = "usesCustomExportSchedule";
-    static final String STUDY_DISABLE_EXPORT = "disableExport";
 
     static final String IDENTIFIER = "identifier";
     static final String LAST_EXPORT_DATE_TIME = "lastExportDateTime";
@@ -153,15 +154,20 @@ public class DynamoHelper {
             studyInfoBuilder.withSynapseProjectId(studyItem.getString(STUDY_INFO_KEY_PROJECT_ID));
         }
 
-        if (studyItem.get(STUDY_INFO_KEY_USES_CUSTOM_EXPORT_SCHEDULE) != null) {
+        if (studyItem.get(STUDY_DISABLE_EXPORT) != null) {
             // For some reason, the mapper saves the value as an int, not as a boolean.
+            boolean disableExport = parseDdbBoolean(studyItem, STUDY_DISABLE_EXPORT);
+            studyInfoBuilder.withDisableExport(disableExport);
+        }
+
+        if (studyItem.get(STUDY_INFO_KEY_USES_CUSTOM_EXPORT_SCHEDULE) != null) {
             boolean usesCustomExportSchedule = parseDdbBoolean(studyItem, STUDY_INFO_KEY_USES_CUSTOM_EXPORT_SCHEDULE);
             studyInfoBuilder.withUsesCustomExportSchedule(usesCustomExportSchedule);
         }
 
-        if (studyItem.get(STUDY_DISABLE_EXPORT) != null) {
-            boolean disableExport = parseDdbBoolean(studyItem, STUDY_DISABLE_EXPORT);
-            studyInfoBuilder.withDisableExport(disableExport);
+        if (studyItem.get(STUDY_INFO_KEY_STUDY_ID_EXCLUDED_IN_EXPORT) != null) {
+            boolean studyIdExcludedInExport = parseDdbBoolean(studyItem, STUDY_INFO_KEY_STUDY_ID_EXCLUDED_IN_EXPORT);
+            studyInfoBuilder.withStudyIdExcludedInExport(studyIdExcludedInExport);
         }
 
         return studyInfoBuilder.build();

--- a/src/main/java/org/sagebionetworks/bridge/exporter/dynamo/StudyInfo.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/dynamo/StudyInfo.java
@@ -7,27 +7,54 @@ import org.apache.commons.lang.StringUtils;
  * populated, THIS SHOULD NOT BE CHANGED. Otherwise, bad things happen.
  */
 public class StudyInfo {
-    private final Long dataAccessTeamId;
+    private final long dataAccessTeamId;
     private final String synapseProjectId;
-    private final boolean usesCustomExportSchedule;
     private final boolean disableExport;
+    private final boolean studyIdExcludedInExport;
+    private final boolean usesCustomExportSchedule;
 
     /** Private constructor. To construct, see builder. */
-    private StudyInfo(Long dataAccessTeamId, String synapseProjectId, boolean usesCustomExportSchedule, boolean disableExport) {
+    private StudyInfo(long dataAccessTeamId, String synapseProjectId, boolean disableExport,
+            boolean studyIdExcludedInExport, boolean usesCustomExportSchedule) {
         this.dataAccessTeamId = dataAccessTeamId;
         this.synapseProjectId = synapseProjectId;
-        this.usesCustomExportSchedule = usesCustomExportSchedule;
         this.disableExport = disableExport;
+        this.studyIdExcludedInExport = studyIdExcludedInExport;
+        this.usesCustomExportSchedule = usesCustomExportSchedule;
     }
 
     /** The team ID of the team that is granted read access to exported data. */
-    public Long getDataAccessTeamId() {
+    public long getDataAccessTeamId() {
         return dataAccessTeamId;
     }
 
     /** The Synapse project to export the data to. */
     public String getSynapseProjectId() {
         return synapseProjectId;
+    }
+
+    /** Flag indicating if this study should be excluded from exporting. */
+    public boolean getDisableExport() {
+        return disableExport;
+    }
+
+    /**
+     * <p>
+     * True if the Bridge Exporter should include the studyId prefix in the "originalTable" field in the appVersion
+     * (now "Health Data Summary") table in Synapse. This exists primarily because we want to remove redundant prefixes
+     * from the Synapse tables (to improve reporting), but we don't want to break existing studies or partition
+     * existing data.
+     * </p>
+     * <p>
+     * The setting is "reversed" so we don't have to backfill a bunch of old studies.
+     * </p>
+     * <p>
+     * This is a "hidden" setting, primarily to support back-compat for old studies. New studies should be created with
+     * this flag set to true, and only admins can change the flag.
+     * </p>
+     */
+    public boolean isStudyIdExcludedInExport() {
+        return studyIdExcludedInExport;
     }
 
     /**
@@ -38,21 +65,16 @@ public class StudyInfo {
         return usesCustomExportSchedule;
     }
 
-    /** Flag indicating if this study should be excluded from exporting. */
-    public boolean getDisableExport() {
-        return disableExport;
-    }
-
-
     /** StudyInfo Builder. */
     public static class Builder {
         private Long dataAccessTeamId;
         private String synapseProjectId;
-        private Boolean usesCustomExportSchedule;
         private boolean disableExport;
+        private boolean studyIdExcludedInExport;
+        private boolean usesCustomExportSchedule;
 
         /** @see StudyInfo#getDataAccessTeamId */
-        public Builder withDataAccessTeamId(Long dataAccessTeamId) {
+        public Builder withDataAccessTeamId(long dataAccessTeamId) {
             this.dataAccessTeamId = dataAccessTeamId;
             return this;
         }
@@ -64,14 +86,20 @@ public class StudyInfo {
         }
 
         /** @see StudyInfo#getUsesCustomExportSchedule */
-        public Builder withUsesCustomExportSchedule(Boolean usesCustomExportSchedule) {
-            this.usesCustomExportSchedule = usesCustomExportSchedule;
+        public Builder withDisableExport(boolean disableExport) {
+            this.disableExport = disableExport;
+            return this;
+        }
+
+        /** @see StudyInfo#isStudyIdExcludedInExport */
+        public Builder withStudyIdExcludedInExport(boolean studyIdExcludedInExport) {
+            this.studyIdExcludedInExport = studyIdExcludedInExport;
             return this;
         }
 
         /** @see StudyInfo#getUsesCustomExportSchedule */
-        public Builder withDisableExport(boolean disableExport) {
-            this.disableExport = disableExport;
+        public Builder withUsesCustomExportSchedule(boolean usesCustomExportSchedule) {
+            this.usesCustomExportSchedule = usesCustomExportSchedule;
             return this;
         }
 
@@ -85,11 +113,8 @@ public class StudyInfo {
                 return null;
             }
 
-            // usesCustomExportSchedule defaults to false.
-            boolean finalUsesCustomExportSchedule = usesCustomExportSchedule != null ? usesCustomExportSchedule :
-                    false;
-
-            return new StudyInfo(dataAccessTeamId, synapseProjectId, finalUsesCustomExportSchedule, disableExport);
+            return new StudyInfo(dataAccessTeamId, synapseProjectId, disableExport, studyIdExcludedInExport,
+                    usesCustomExportSchedule);
         }
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/exporter/handler/AppVersionExportHandler.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/handler/AppVersionExportHandler.java
@@ -14,6 +14,7 @@ import org.sagebionetworks.bridge.exporter.synapse.SynapseHelper;
 import org.sagebionetworks.bridge.exporter.worker.ExportSubtask;
 import org.sagebionetworks.bridge.exporter.worker.ExportTask;
 import org.sagebionetworks.bridge.exporter.worker.TsvInfo;
+import org.sagebionetworks.bridge.schema.UploadSchemaKey;
 
 /**
  * Synapse export worker for app version tables. The app version is a master table keeping track of all records by
@@ -80,9 +81,18 @@ public class AppVersionExportHandler extends SynapseExportHandler {
             task.getMetrics().addKeyValuePair("uniqueAppVersions[" + getStudyId() + "]", appVersion);
         }
 
+        // check isStudyIdExcludedInExport to see how we should format the originalTable value
+        UploadSchemaKey schemaKey = subtask.getSchemaKey();
+        String originalTable;
+        if (getManager().isStudyIdExcludedInExportForStudy(schemaKey.getStudyId())) {
+            originalTable = schemaKey.getSchemaId() + "-v" + schemaKey.getRevision();
+        } else {
+            originalTable = schemaKey.toString();
+        }
+
         // construct row
         Map<String, String> rowValueMap = new HashMap<>();
-        rowValueMap.put("originalTable", subtask.getSchemaKey().toString());
+        rowValueMap.put("originalTable", originalTable);
         return rowValueMap;
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/exporter/worker/ExportWorkerManager.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/worker/ExportWorkerManager.java
@@ -305,6 +305,13 @@ public class ExportWorkerManager {
         return studyInfo.getDataAccessTeamId();
     }
 
+    /** Convenience method to get the studyIdExcludedInExport flag for the given study. */
+    public boolean isStudyIdExcludedInExportForStudy(String studyId) {
+        // Study info is cached. No need to worry about repeat calls.
+        StudyInfo studyInfo = dynamoHelper.getStudyInfo(studyId);
+        return studyInfo.isStudyIdExcludedInExport();
+    }
+
     /**
      * The Synapse project ID to export to. This first checks the task's request for the project override, then falls
      * back to Dynamo DB.

--- a/src/test/java/org/sagebionetworks/bridge/exporter/dynamo/StudyInfoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/dynamo/StudyInfoTest.java
@@ -36,31 +36,13 @@ public class StudyInfoTest {
     public void withFields() {
         StudyInfo studyInfo = new StudyInfo.Builder().withDataAccessTeamId(23L)
                 .withSynapseProjectId("test-synapse-project").build();
-        assertEquals(studyInfo.getDataAccessTeamId().longValue(), 23);
+        assertEquals(studyInfo.getDataAccessTeamId(), 23);
         assertEquals(studyInfo.getSynapseProjectId(), "test-synapse-project");
-        assertFalse(studyInfo.getUsesCustomExportSchedule());
+
+        // optional args default to false
         assertFalse(studyInfo.getDisableExport());
-    }
-
-    @Test
-    public void customExportFalse() {
-        StudyInfo studyInfo = new StudyInfo.Builder().withDataAccessTeamId(23L)
-                .withSynapseProjectId("test-synapse-project").withUsesCustomExportSchedule(false).build();
+        assertFalse(studyInfo.isStudyIdExcludedInExport());
         assertFalse(studyInfo.getUsesCustomExportSchedule());
-    }
-
-    @Test
-    public void customExportTrue() {
-        StudyInfo studyInfo = new StudyInfo.Builder().withDataAccessTeamId(23L)
-                .withSynapseProjectId("test-synapse-project").withUsesCustomExportSchedule(true).build();
-        assertTrue(studyInfo.getUsesCustomExportSchedule());
-    }
-
-    @Test
-    public void disableExportFalse() {
-        StudyInfo studyInfo = new StudyInfo.Builder().withDataAccessTeamId(23L)
-                .withSynapseProjectId("test-synapse-project").withDisableExport(false).build();
-        assertFalse(studyInfo.getDisableExport());
     }
 
     @Test
@@ -68,5 +50,19 @@ public class StudyInfoTest {
         StudyInfo studyInfo = new StudyInfo.Builder().withDataAccessTeamId(23L)
                 .withSynapseProjectId("test-synapse-project").withDisableExport(true).build();
         assertTrue(studyInfo.getDisableExport());
+    }
+
+    @Test
+    public void studyIdExcludedInExport() {
+        StudyInfo studyInfo = new StudyInfo.Builder().withDataAccessTeamId(23L)
+                .withSynapseProjectId("test-synapse-project").withStudyIdExcludedInExport(true).build();
+        assertTrue(studyInfo.isStudyIdExcludedInExport());
+    }
+
+    @Test
+    public void customExportTrue() {
+        StudyInfo studyInfo = new StudyInfo.Builder().withDataAccessTeamId(23L)
+                .withSynapseProjectId("test-synapse-project").withUsesCustomExportSchedule(true).build();
+        assertTrue(studyInfo.getUsesCustomExportSchedule());
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/exporter/handler/SynapseExportHandlerNewTableTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/handler/SynapseExportHandlerNewTableTest.java
@@ -132,11 +132,12 @@ public class SynapseExportHandlerNewTableTest {
             return 1;
         });
 
-        // spy getSynapseProjectId and getDataAccessTeam
+        // spy StudyInfo getters
         // These calls through to a bunch of stuff (which we test in ExportWorkerManagerTest), so to simplify our test,
         // we just use a spy here.
         doReturn(SynapseExportHandlerTest.TEST_SYNAPSE_PROJECT_ID).when(manager).getSynapseProjectIdForStudyAndTask(
                 eq(SynapseExportHandlerTest.TEST_STUDY_ID), same(task));
+        doReturn(false).when(manager).isStudyIdExcludedInExportForStudy(SynapseExportHandlerTest.TEST_STUDY_ID);
         doReturn(SynapseExportHandlerTest.TEST_SYNAPSE_DATA_ACCESS_TEAM_ID).when(manager).getDataAccessTeamIdForStudy(
                 SynapseExportHandlerTest.TEST_STUDY_ID);
 

--- a/src/test/java/org/sagebionetworks/bridge/exporter/worker/ExportWorkerManagerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/worker/ExportWorkerManagerTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
 
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -143,6 +144,23 @@ public class ExportWorkerManagerTest {
         // execute and validate
         long teamId = manager.getDataAccessTeamIdForStudy("test-study");
         assertEquals(teamId, 1337L);
+    }
+
+    @Test
+    public void isStudyIdExcludedInExportForStudy() {
+        // mock DynamoHelper
+        StudyInfo testStudyInfo = new StudyInfo.Builder().withDataAccessTeamId(1337L)
+                .withSynapseProjectId("project-id").withStudyIdExcludedInExport(true).build();
+        DynamoHelper mockDynamoHelper = mock(DynamoHelper.class);
+        when(mockDynamoHelper.getStudyInfo("test-study")).thenReturn(testStudyInfo);
+
+        // set up worker manager
+        ExportWorkerManager manager = new ExportWorkerManager();
+        manager.setDynamoHelper(mockDynamoHelper);
+
+        // execute and validate
+        boolean studyIdExcludedInExport = manager.isStudyIdExcludedInExportForStudy("test-study");
+        assertTrue(studyIdExcludedInExport);
     }
 
     @Test


### PR DESCRIPTION
See https://sagebionetworks.jira.com/browse/BRIDGE-1942

This is needed because we want new studies to not include studyId in the exported data, but we don't want to break old studies. This flag is only changeable by admins. It defaults to false, and new studies are created with this flag set to true.