### PR TITLE
More Mutable Schemas

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <dependency>
             <groupId>org.sagebionetworks</groupId>
             <artifactId>synapseJavaClient</artifactId>
-            <version>157.0</version>
+            <version>199.0</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/java/org/sagebionetworks/bridge/exporter/config/SpringConfig.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/config/SpringConfig.java
@@ -56,6 +56,7 @@ public class SpringConfig {
 
     @Bean
     public Config bridgeConfig() {
+        //noinspection ConstantConditions
         String defaultConfig = getClass().getClassLoader().getResource(DEFAULT_CONFIG_FILE).getPath();
         Path defaultConfigPath = Paths.get(defaultConfig);
         Path localConfigPath = Paths.get(USER_CONFIG_FILE);
@@ -197,7 +198,7 @@ public class SpringConfig {
         Config config = bridgeConfig();
 
         SynapseClient synapseClient = new SynapseAdminClientImpl();
-        synapseClient.setUserName(config.get("synapse.user"));
+        synapseClient.setUsername(config.get("synapse.user"));
         synapseClient.setApiKey(config.get("synapse.api.key"));
         return synapseClient;
     }
@@ -210,6 +211,7 @@ public class SpringConfig {
     @Bean(name = "synapseColumnDefinitions")
     public List<ColumnDefinition> synapseColumnDefinitions() throws IOException {
         final ClassLoader classLoader = getClass().getClassLoader();
+        //noinspection ConstantConditions
         final File file = new File(classLoader.getResource("ColumnDefinition.json").getFile());
         final ObjectMapper mapper = DefaultObjectMapper.INSTANCE;
 

--- a/src/main/java/org/sagebionetworks/bridge/exporter/synapse/SynapseHelper.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/synapse/SynapseHelper.java
@@ -79,14 +79,16 @@ public class SynapseHelper {
     // numeric types, but new values are likely to be "true"/"false" or ISO8601 timestamps. This leads to more
     // confusion overall, so we've decided to block it.
     //
+    // Similarly, if you convert a bool to a numeric type (int, float), Synapse will convert the bools to 0s and 1s.
+    // However, old bools in DynamoDB are still using "true"/"false", which will no longer serialize to Synapse. To
+    // prevent this data loss, we're also not allowing bools to convert to numeric types.
+    //
     // Also note that due to a bug, we cannot currently convert anything to a LargeText.
     // See https://sagebionetworks.jira.com/browse/PLFM-4028
     private static final SetMultimap<ColumnType, ColumnType> ALLOWED_OLD_TYPE_TO_NEW_TYPE =
             ImmutableSetMultimap.<ColumnType, ColumnType>builder()
-                    // Numeric types can changed to types with more precision (bool to int to float), but not less
-                    // precision (float to int to bool).
-                    .put(ColumnType.BOOLEAN, ColumnType.INTEGER)
-                    .put(ColumnType.BOOLEAN, ColumnType.DOUBLE)
+                    // Numeric types can changed to types with more precision (int to float), but not less
+                    // precision (float to int).
                     .put(ColumnType.INTEGER, ColumnType.DOUBLE)
                     // Date can be converted to int and float (epoch milliseconds), and can be converted back from an
                     // int. However, we block converting from float, since that causes data loss.

--- a/src/test/java/org/sagebionetworks/bridge/exporter/synapse/SynapseHelperUpdateTableColumnsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/synapse/SynapseHelperUpdateTableColumnsTest.java
@@ -1,0 +1,162 @@
+package org.sagebionetworks.bridge.exporter.synapse;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.fail;
+
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+import org.mockito.ArgumentCaptor;
+import org.sagebionetworks.client.SynapseClient;
+import org.sagebionetworks.client.exceptions.SynapseResultNotReadyException;
+import org.sagebionetworks.repo.model.table.TableSchemaChangeRequest;
+import org.sagebionetworks.repo.model.table.TableSchemaChangeResponse;
+import org.sagebionetworks.repo.model.table.TableUpdateRequest;
+import org.sagebionetworks.repo.model.table.TableUpdateResponse;
+import org.sagebionetworks.repo.model.table.UploadToTableResult;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import org.sagebionetworks.bridge.config.Config;
+import org.sagebionetworks.bridge.exporter.exceptions.BridgeExporterException;
+
+@SuppressWarnings({ "rawtypes", "unchecked" })
+public class SynapseHelperUpdateTableColumnsTest {
+    private static final TableSchemaChangeRequest DUMMY_REQUEST = new TableSchemaChangeRequest();
+    private static final String JOB_TOKEN = "job-token";
+    private static final String TABLE_ID = "table-id";
+
+    private ArgumentCaptor<List> changeListCaptor;
+    private SynapseClient mockSynapseClient;
+    private SynapseHelper synapseHelper;
+
+    @BeforeMethod
+    public void setup() throws Exception {
+        // mock config
+        Config config = mock(Config.class);
+        when(config.getInt(SynapseHelper.CONFIG_KEY_SYNAPSE_ASYNC_INTERVAL_MILLIS)).thenReturn(0);
+        when(config.getInt(SynapseHelper.CONFIG_KEY_SYNAPSE_ASYNC_TIMEOUT_LOOPS)).thenReturn(2);
+        // Set a very high number for rate limiting, since we don't want the rate limiter to interfere with our tests.
+        when(config.getInt(SynapseHelper.CONFIG_KEY_SYNAPSE_RATE_LIMIT_PER_SECOND)).thenReturn(1000);
+
+        // mock Synapse Client and startTableTransactionJob
+        mockSynapseClient = mock(SynapseClient.class);
+
+        changeListCaptor = ArgumentCaptor.forClass(List.class);
+        when(mockSynapseClient.startTableTransactionJob(changeListCaptor.capture(), eq(TABLE_ID))).thenReturn(
+                JOB_TOKEN);
+
+        // create Synapse Helper
+        synapseHelper = new SynapseHelper();
+        synapseHelper.setConfig(config);
+        synapseHelper.setSynapseClient(mockSynapseClient);
+    }
+
+    @Test
+    public void immediateSuccess() throws Exception {
+        // mock SynapseClient.getTableTransationJobResults
+        TableSchemaChangeResponse singleResponse = new TableSchemaChangeResponse();
+        List<TableUpdateResponse> responseList = ImmutableList.of(singleResponse);
+        when(mockSynapseClient.getTableTransactionJobResults(JOB_TOKEN, TABLE_ID)).thenReturn(responseList);
+
+        // execute and validate
+        TableSchemaChangeResponse retVal = synapseHelper.updateTableColumns(DUMMY_REQUEST, TABLE_ID);
+        assertSame(retVal, singleResponse);
+        verify(mockSynapseClient, times(1)).getTableTransactionJobResults(any(), any());
+        validateInputList();
+    }
+
+    @Test
+    public void secondTry() throws Exception {
+        // mock SynapseClient.getTableTransationJobResults
+        TableSchemaChangeResponse singleResponse = new TableSchemaChangeResponse();
+        List<TableUpdateResponse> responseList = ImmutableList.of(singleResponse);
+        when(mockSynapseClient.getTableTransactionJobResults(JOB_TOKEN, TABLE_ID))
+                .thenThrow(SynapseResultNotReadyException.class).thenReturn(responseList);
+
+        // execute and validate
+        TableSchemaChangeResponse retVal = synapseHelper.updateTableColumns(DUMMY_REQUEST, TABLE_ID);
+        assertSame(retVal, singleResponse);
+        verify(mockSynapseClient, times(2)).getTableTransactionJobResults(any(), any());
+        validateInputList();
+    }
+
+    @Test
+    public void timeout() throws Exception {
+        // mock SynapseClient.getTableTransationJobResults
+        when(mockSynapseClient.getTableTransactionJobResults(JOB_TOKEN, TABLE_ID))
+                .thenThrow(SynapseResultNotReadyException.class);
+
+        // execute and validate
+        try {
+            synapseHelper.updateTableColumns(DUMMY_REQUEST, TABLE_ID);
+            fail("expected exception");
+        } catch (BridgeExporterException ex) {
+            assertEquals(ex.getMessage(), "Timed out updating table columns for table " + TABLE_ID);
+        }
+        verify(mockSynapseClient, times(2)).getTableTransactionJobResults(any(), any());
+        validateInputList();
+    }
+
+    @Test
+    public void emptyResponseList() throws Exception {
+        // mock SynapseClient.getTableTransationJobResults
+        when(mockSynapseClient.getTableTransactionJobResults(JOB_TOKEN, TABLE_ID)).thenReturn(ImmutableList.of());
+
+        // execute and validate
+        try {
+            synapseHelper.updateTableColumns(DUMMY_REQUEST, TABLE_ID);
+            fail("expected exception");
+        } catch (BridgeExporterException ex) {
+            assertEquals(ex.getMessage(), "Expected one table update response for table " + TABLE_ID + ", but got 0");
+        }
+        validateInputList();
+    }
+
+    @Test
+    public void multipleResponses() throws Exception {
+        // mock SynapseClient.getTableTransationJobResults
+        when(mockSynapseClient.getTableTransactionJobResults(JOB_TOKEN, TABLE_ID)).thenReturn(ImmutableList.of(
+                new TableSchemaChangeResponse(), new TableSchemaChangeResponse()));
+
+        // execute and validate
+        try {
+            synapseHelper.updateTableColumns(DUMMY_REQUEST, TABLE_ID);
+            fail("expected exception");
+        } catch (BridgeExporterException ex) {
+            assertEquals(ex.getMessage(), "Expected one table update response for table " + TABLE_ID + ", but got 2");
+        }
+        validateInputList();
+    }
+
+    @Test
+    public void responseNotSchemaChange() throws Exception {
+        // mock SynapseClient.getTableTransationJobResults
+        when(mockSynapseClient.getTableTransactionJobResults(JOB_TOKEN, TABLE_ID)).thenReturn(ImmutableList.of(
+                new UploadToTableResult()));
+
+        // execute and validate
+        try {
+            synapseHelper.updateTableColumns(DUMMY_REQUEST, TABLE_ID);
+            fail("expected exception");
+        } catch (BridgeExporterException ex) {
+            assertEquals(ex.getMessage(), "Expected a TableSchemaChangeResponse for table " + TABLE_ID + ", but got " +
+                    UploadToTableResult.class.getName());
+        }
+        validateInputList();
+    }
+
+    // This is done as a helper method instead of an After, so we can know which test failed.
+    private void validateInputList() {
+        List<TableUpdateRequest> changeList = changeListCaptor.getValue();
+        assertEquals(changeList.size(), 1);
+        assertSame(changeList.get(0), DUMMY_REQUEST);
+    }
+}

--- a/src/test/java/org/sagebionetworks/bridge/exporter/synapse/SynapseHelperUploadTsvToTableTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/synapse/SynapseHelperUploadTsvToTableTest.java
@@ -10,6 +10,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
 import java.io.File;
+import java.util.List;
 
 import org.mockito.ArgumentCaptor;
 import org.sagebionetworks.client.SynapseClient;
@@ -53,7 +54,8 @@ public class SynapseHelperUploadTsvToTableTest {
 
         tableDescCaptor = ArgumentCaptor.forClass(CsvTableDescriptor.class);
         when(mockSynapseClient.uploadCsvToTableAsyncStart(eq(TEST_TABLE_ID), eq(TEST_FILE_HANDLE_ID),
-                isNull(String.class), isNull(Long.class), tableDescCaptor.capture())).thenReturn(TEST_JOB_TOKEN);
+                isNull(String.class), isNull(Long.class), tableDescCaptor.capture(), isNull(List.class))).thenReturn(
+                TEST_JOB_TOKEN);
 
         synapseHelper = spy(new SynapseHelper());
         synapseHelper.setConfig(config);


### PR DESCRIPTION
Now that Synapse table columns are mutable, we should propagate that change to Bridge schemas. See https://sagebionetworks.jira.com/browse/BRIDGE-1863

This change allows certain field type changes and allows an increase in string lengths.

Testing done:
* mvn verify (unit tests, Jacoco test coverage, findbugs)
* integ tests
* manual tests

Manual test cases:
* modify a schema to add fields and re-order other fields
* modify a schema to modify fields and re-order other fields
* change a field from bool to int
* change a field from int to float
* change a field from int to timestamp
* change a field from float to string
* increase string length