### PR TITLE
extra rate limiting for SynapseClient.getColumnModelsForTableEntity()

### DIFF
--- a/src/main/resources/BridgeExporter.conf
+++ b/src/main/resources/BridgeExporter.conf
@@ -17,6 +17,7 @@ record.loop.progress.report.period=1000
 synapse.async.interval.millis = 1000
 synapse.async.timeout.loops = 300
 synapse.rate.limit.per.second = 10
+synapse.get.column.models.rate.limit.per.minute = 24
 threadpool.worker.count=4
 time.zone.name=America/Los_Angeles
 worker.manager.progress.report.period=250

--- a/src/test/java/org/sagebionetworks/bridge/exporter/synapse/SynapseHelperSerializeTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/synapse/SynapseHelperSerializeTest.java
@@ -191,6 +191,8 @@ public class SynapseHelperSerializeTest {
         when(mockConfig.getInt(SynapseHelper.CONFIG_KEY_SYNAPSE_ASYNC_TIMEOUT_LOOPS)).thenReturn(2);
         // Set a very high number for rate limiting, since we don't want the rate limiter to interfere with our tests.
         when(mockConfig.getInt(SynapseHelper.CONFIG_KEY_SYNAPSE_RATE_LIMIT_PER_SECOND)).thenReturn(1000);
+        when(mockConfig.getInt(SynapseHelper.CONFIG_KEY_SYNAPSE_GET_COLUMN_MODELS_RATE_LIMIT_PER_MINUTE)).thenReturn(
+                1000);
 
         // Mock S3Helper.
         S3Helper mockS3Helper = mock(S3Helper.class);

--- a/src/test/java/org/sagebionetworks/bridge/exporter/synapse/SynapseHelperUpdateTableColumnsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/synapse/SynapseHelperUpdateTableColumnsTest.java
@@ -45,6 +45,7 @@ public class SynapseHelperUpdateTableColumnsTest {
         when(config.getInt(SynapseHelper.CONFIG_KEY_SYNAPSE_ASYNC_TIMEOUT_LOOPS)).thenReturn(2);
         // Set a very high number for rate limiting, since we don't want the rate limiter to interfere with our tests.
         when(config.getInt(SynapseHelper.CONFIG_KEY_SYNAPSE_RATE_LIMIT_PER_SECOND)).thenReturn(1000);
+        when(config.getInt(SynapseHelper.CONFIG_KEY_SYNAPSE_GET_COLUMN_MODELS_RATE_LIMIT_PER_MINUTE)).thenReturn(1000);
 
         // mock Synapse Client and startTableTransactionJob
         mockSynapseClient = mock(SynapseClient.class);

--- a/src/test/java/org/sagebionetworks/bridge/exporter/synapse/SynapseHelperUploadAttachmentTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/synapse/SynapseHelperUploadAttachmentTest.java
@@ -250,6 +250,8 @@ public class SynapseHelperUploadAttachmentTest {
 
         // Set a very high number for rate limiting, since we don't want the rate limiter to interfere with our tests.
         when(mockConfig.getInt(SynapseHelper.CONFIG_KEY_SYNAPSE_RATE_LIMIT_PER_SECOND)).thenReturn(1000);
+        when(mockConfig.getInt(SynapseHelper.CONFIG_KEY_SYNAPSE_GET_COLUMN_MODELS_RATE_LIMIT_PER_MINUTE)).thenReturn(
+                1000);
 
         return mockConfig;
     }

--- a/src/test/java/org/sagebionetworks/bridge/exporter/synapse/SynapseHelperUploadTsvToTableTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/synapse/SynapseHelperUploadTsvToTableTest.java
@@ -48,6 +48,7 @@ public class SynapseHelperUploadTsvToTableTest {
         when(config.getInt(SynapseHelper.CONFIG_KEY_SYNAPSE_ASYNC_TIMEOUT_LOOPS)).thenReturn(2);
         // Set a very high number for rate limiting, since we don't want the rate limiter to interfere with our tests.
         when(config.getInt(SynapseHelper.CONFIG_KEY_SYNAPSE_RATE_LIMIT_PER_SECOND)).thenReturn(1000);
+        when(config.getInt(SynapseHelper.CONFIG_KEY_SYNAPSE_GET_COLUMN_MODELS_RATE_LIMIT_PER_MINUTE)).thenReturn(1000);
 
         // mock Synapse Client - Mock everything except uploadCsvToTableAsyncGet(), which depends on the test.
         mockSynapseClient = mock(SynapseClient.class);


### PR DESCRIPTION
See https://sagebionetworks.jira.com/browse/PLFM-4673

Synapse team fixed and turned on extra throttling for expensive API calls earlier this week. This led to extra throttles in Production. I added a separate rate limiter for getColumnModels(), and an extra config so we can tweak this setting in the future without needing a code push.

This change is primarily a rate limiting change, not a functionality change, so there's not much I can do to test this specific change. However, I did run mvn verify (unit tests, FindBugs, Jacoco test coverage) and integ tests to make sure there are no regressions.