### PR TITLE
Deploy app to new AWS bridge-exporter environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,11 @@ deploy:
   secret_access_key:
     secure: IVPBSeFrGy/Oe4Jgxmp5BxTCEe1IuCQTPcZcmLr5E2FzVRqq7W7sKEOT8KKvt6OlpF+MUBY6jqJVT9AYweZqw7XrqzYzzLNIwWKwEMUptLlk46gOp0H6TWHPlSBf0jSB3OpaUkIbhaXTykyflyP4pYXzWAse/FL0T4kOCMaa4Fc=
   region: us-east-1
-  app: Bridge-EX
+  app: bridge-exporter-$TRAVIS_BRANCH-application
   env:
-    develop: Bridge-EX-Dev
-    uat: Bridge-EX-Uat
-    prod: Bridge-EX-Prod
+    develop: bridge-exporter-develop
+    uat: bridge-exporter-uat
+    prod: bridge-exporter-prod
   bucket_name: elasticbeanstalk-us-east-1-649232250620
   zip-file: target/Bridge-Exporter-2.0.war
   on:

--- a/src/main/resources/BridgeExporter.conf
+++ b/src/main/resources/BridgeExporter.conf
@@ -32,9 +32,9 @@ uat.exporter.ddb.prefix = uat-exporter-
 prod.exporter.ddb.prefix = prod-exporter-
 
 local.exporter.request.sqs.queue.url=https://sqs.us-east-1.amazonaws.com/649232250620/Bridge-EX-Request-local
-dev.exporter.request.sqs.queue.url=https://sqs.us-east-1.amazonaws.com/649232250620/Bridge-EX-Request-dev
-uat.exporter.request.sqs.queue.url=https://sqs.us-east-1.amazonaws.com/649232250620/Bridge-EX-Request-uat
-prod.exporter.request.sqs.queue.url=https://sqs.us-east-1.amazonaws.com/649232250620/Bridge-EX-Request-prod
+dev.exporter.request.sqs.queue.url=https://sqs.us-east-1.amazonaws.com/649232250620/awseb-e-mi3sym9mrs-stack-AWSEBWorkerQueue-1W434RXLTTRO1
+uat.exporter.request.sqs.queue.url=https://sqs.us-east-1.amazonaws.com/649232250620/awseb-e-agmuuqbanv-stack-AWSEBWorkerQueue-QTOVH1V7SHS6
+prod.exporter.request.sqs.queue.url=https://sqs.us-east-1.amazonaws.com/649232250620/awseb-e-8fm2xp95rm-stack-AWSEBWorkerQueue-1ELXM125D5PL2
 
 local.s3.notification.sqs.queue.url=https://sqs.us-east-1.amazonaws.com/649232250620/Bridge-UploadComplete-Notification-local
 dev.s3.notification.sqs.queue.url=https://sqs.us-east-1.amazonaws.com/649232250620/Bridge-UploadComplete-Notification-dev


### PR DESCRIPTION
The infra for Bridge-Exporter app is now automated with
Bridge-Exporter-infra[1] repo.  This new project uses cloudformation
to setup the bridge exporter env and SQS queues. We should switch to
using this environment and deprecate the manually created exporter
environment.

[1] https://github.com/Sage-Bionetworks/Bridge-Exporter-infra