### PR TITLE
increase data group column size to 250

### DIFF
--- a/src/main/resources/ColumnDefinition.json
+++ b/src/main/resources/ColumnDefinition.json
@@ -13,7 +13,7 @@
   },
   {
     "name": "dataGroups",
-    "maximumSize": 100,
+    "maximumSize": 250,
     "transferMethod": "STRINGSET",
     "ddbName": "userDataGroups"
   },


### PR DESCRIPTION
Testing done: Manually tested, verified that the data group column updates from 100 to 250 max length.