### PR TITLE
default tag to fix null pointer exception

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/exporter/request/BridgeExporterRequest.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/request/BridgeExporterRequest.java
@@ -20,6 +20,8 @@ import org.sagebionetworks.bridge.schema.UploadSchemaKey;
 @JsonDeserialize(builder = BridgeExporterRequest.Builder.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class BridgeExporterRequest {
+    static final String DEFAULT_TAG = "(no tag)";
+
     private final DateTime startDateTime;
     private final DateTime endDateTime;
     private final String exporterDdbPrefixOverride;
@@ -142,7 +144,7 @@ public class BridgeExporterRequest {
         if (this == o) {
             return true;
         }
-        if (o == null || !(o instanceof BridgeExporterRequest)) {
+        if (!(o instanceof BridgeExporterRequest)) {
             return false;
         }
         BridgeExporterRequest that = (BridgeExporterRequest) o;
@@ -375,7 +377,10 @@ public class BridgeExporterRequest {
                 sharingMode = BridgeExporterSharingMode.SHARED;
             }
 
-            // tag is always optional and doesn't need to be validated
+            // Tag is optional but must be non-null. If null, replace with default tag.
+            if (tag == null) {
+                tag = DEFAULT_TAG;
+            }
 
             // Replace collections with immutable copies, to maintain request object integrity.
             if (studyWhitelist != null) {

--- a/src/test/java/org/sagebionetworks/bridge/exporter/request/BridgeExporterRequestTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/request/BridgeExporterRequestTest.java
@@ -42,10 +42,11 @@ public class BridgeExporterRequestTest {
         assertEquals(request.getEndDateTime(), END_DATE_TIME);
         assertEquals(request.getSharingMode(), BridgeExporterSharingMode.SHARED);
         assertTrue(request.getUseLastExportTime());
+        assertEquals(request.getTag(), BridgeExporterRequest.DEFAULT_TAG);
 
         // test toString
-        assertEquals(request.toString(), "endDateTime=" + END_DATE_TIME + ", redriveCount=0, tag=null, " +
-                "useLastExportTime=true");
+        assertEquals(request.toString(), "endDateTime=" + END_DATE_TIME + ", redriveCount=0, tag=" +
+                BridgeExporterRequest.DEFAULT_TAG + ", " + "useLastExportTime=true");
 
         // test copy
         BridgeExporterRequest copy = new BridgeExporterRequest.Builder().copyOf(request).build();
@@ -60,10 +61,11 @@ public class BridgeExporterRequestTest {
         assertEquals(request.getEndDateTime(), END_DATE_TIME);
         assertEquals(request.getSharingMode(), BridgeExporterSharingMode.SHARED);
         assertFalse(request.getUseLastExportTime());
+        assertEquals(request.getTag(), BridgeExporterRequest.DEFAULT_TAG);
 
         // test toString
         assertEquals(request.toString(), "startDateTime=" + START_DATE_TIME + ", endDateTime=" + END_DATE_TIME +
-                ", redriveCount=0, tag=null, useLastExportTime=false");
+                ", redriveCount=0, tag=" + BridgeExporterRequest.DEFAULT_TAG + ", useLastExportTime=false");
 
         // test copy
         BridgeExporterRequest copy = new BridgeExporterRequest.Builder().copyOf(request).build();
@@ -77,10 +79,11 @@ public class BridgeExporterRequestTest {
         assertEquals(request.getRecordIdS3Override(), TEST_RECORD_OVERRIDE);
         assertEquals(request.getSharingMode(), BridgeExporterSharingMode.SHARED);
         assertFalse(request.getUseLastExportTime());
+        assertEquals(request.getTag(), BridgeExporterRequest.DEFAULT_TAG);
 
         // test toString
         assertEquals(request.toString(), "recordIdS3Override=" + TEST_RECORD_OVERRIDE + ", redriveCount=0, " +
-                "tag=null, useLastExportTime=false");
+                "tag=" + BridgeExporterRequest.DEFAULT_TAG + ", useLastExportTime=false");
 
         // test copy
         BridgeExporterRequest copy = new BridgeExporterRequest.Builder().copyOf(request).build();


### PR DESCRIPTION
Bridge Exporter request without a tag can cause null pointer exception. This change adds a default tag. See also https://sagebionetworks.jira.com/browse/BRIDGE-2273