### PR TITLE
force restart on Synapse multipart upload

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/exporter/synapse/SynapseHelper.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/synapse/SynapseHelper.java
@@ -282,6 +282,7 @@ public class SynapseHelper {
         }
 
         // This should never happen, but if the names are somehow different, they aren't compatible.
+        //noinspection RedundantIfStatement
         if (!Objects.equals(oldColumn.getName(), newColumn.getName())) {
             return false;
         }
@@ -751,7 +752,8 @@ public class SynapseHelper {
     public FileHandle createFileHandleWithRetry(File file, String contentType, String projectId) throws IOException,
             SynapseException {
         rateLimiter.acquire();
-        return synapseClient.multipartUpload(file, null, null, null);
+        // Pass in forceRestart=true. Otherwise, retries will fail deterministically.
+        return synapseClient.multipartUpload(file, null, null, true);
     }
 
     /**

--- a/src/test/java/org/sagebionetworks/bridge/exporter/synapse/SynapseHelperTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/synapse/SynapseHelperTest.java
@@ -238,7 +238,7 @@ public class SynapseHelperTest {
 
         File mockFile = mock(File.class);
         S3FileHandle mockFileHandle = mock(S3FileHandle.class);
-        when(mockSynapseClient.multipartUpload(mockFile, null, null, null)).thenReturn(mockFileHandle);
+        when(mockSynapseClient.multipartUpload(mockFile, null, null, true)).thenReturn(mockFileHandle);
 
         SynapseHelper synapseHelper = new SynapseHelper();
         synapseHelper.setSynapseClient(mockSynapseClient);


### PR DESCRIPTION
See https://sagebionetworks.jira.com/browse/PLFM-5072

This is needed to force a restart on Synapse uploads so that retries and redrives can succeed.