### PR TITLE
add study ID to truncate error log message

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/exporter/handler/HealthDataExportHandler.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/handler/HealthDataExportHandler.java
@@ -336,7 +336,7 @@ public class HealthDataExportHandler extends SynapseExportHandler {
                 rowValueMap.putAll(serializedTimestampFields);
             } else {
                 String value = manager.getSynapseHelper().serializeToSynapseType(task.getMetrics(), task.getTmpDir(),
-                        synapseProjectId, recordId, oneFieldDef, valueNode);
+                        synapseProjectId, recordId, getStudyId(), oneFieldDef, valueNode);
                 rowValueMap.put(oneFieldName, value);
             }
         }

--- a/src/main/java/org/sagebionetworks/bridge/exporter/handler/PhoneAppVersionInfo.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/handler/PhoneAppVersionInfo.java
@@ -24,6 +24,7 @@ public class PhoneAppVersionInfo {
      */
     public static PhoneAppVersionInfo fromRecord(Item record) {
         String recordId = record.getString("id");
+        String studyId = record.getString("studyId");
 
         String appVersion = null;
         String phoneInfo = null;
@@ -31,8 +32,10 @@ public class PhoneAppVersionInfo {
         if (StringUtils.isNotBlank(metadataString)) {
             try {
                 JsonNode metadataJson = DefaultObjectMapper.INSTANCE.readTree(metadataString);
-                appVersion = BridgeExporterUtil.sanitizeJsonValue(metadataJson, "appVersion", 48, recordId);
-                phoneInfo = BridgeExporterUtil.sanitizeJsonValue(metadataJson, "phoneInfo", 48, recordId);
+                appVersion = BridgeExporterUtil.sanitizeJsonValue(metadataJson, "appVersion", 48,
+                        recordId, studyId);
+                phoneInfo = BridgeExporterUtil.sanitizeJsonValue(metadataJson, "phoneInfo", 48,
+                        recordId, studyId);
             } catch (IOException ex) {
                 // We don't want callers to have to deal with boilerplate error handling code, so we log the error and
                 // return null fields.

--- a/src/main/java/org/sagebionetworks/bridge/exporter/synapse/SynapseHelper.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/synapse/SynapseHelper.java
@@ -296,6 +296,8 @@ public class SynapseHelper {
      *         Synapse project ID, used to determine where to upload attachments to
      * @param recordId
      *         Bridge record ID, used for logging
+     * @param studyId
+     *         Bridge study ID, used for logging
      * @param fieldDef
      *         field definition, to determine how to serialize the field
      * @param node
@@ -307,7 +309,7 @@ public class SynapseHelper {
      *         if uploading the attachment to Synapse fails
      */
     public String serializeToSynapseType(Metrics metrics, File tmpDir, String projectId, String recordId,
-            UploadFieldDefinition fieldDef, JsonNode node) throws IOException, SynapseException {
+            String studyId, UploadFieldDefinition fieldDef, JsonNode node) throws IOException, SynapseException {
         if (node == null || node.isNull()) {
             return null;
         }
@@ -360,7 +362,7 @@ public class SynapseHelper {
                 }
 
                 String sanitizedValue = BridgeExporterUtil.sanitizeString(nodeValue, fieldDef.getName(), maxLength,
-                        recordId);
+                        recordId, studyId);
                 return sanitizedValue;
             }
             case FLOAT: {
@@ -385,7 +387,7 @@ public class SynapseHelper {
 
                     // We also need to sanitize the content (remove HTML, newlines, tabs, quote strings, etc).
                     String sanitizedValue = BridgeExporterUtil.sanitizeString(value, fieldDef.getName(), null,
-                            recordId);
+                            recordId, studyId);
                     return sanitizedValue;
                 }
                 return null;

--- a/src/main/java/org/sagebionetworks/bridge/exporter/util/BridgeExporterUtil.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/util/BridgeExporterUtil.java
@@ -117,7 +117,8 @@ public class BridgeExporterUtil {
      */
     public static String sanitizeDdbValue(Item item, String fieldName, int maxLength, String recordId) {
         String value = item.getString(fieldName);
-        return sanitizeString(value, fieldName, maxLength, recordId);
+        String studyId = item.getString("studyId");
+        return sanitizeString(value, fieldName, maxLength, recordId, studyId);
     }
 
     /**
@@ -131,13 +132,16 @@ public class BridgeExporterUtil {
      *         max length of the column
      * @param recordId
      *         record ID, for logging purposes
+     * @param studyId
+     *         study ID, for logging purposes
      * @return sanitized JSON string value
      */
-    public static String sanitizeJsonValue(JsonNode node, String fieldName, int maxLength, String recordId) {
+    public static String sanitizeJsonValue(JsonNode node, String fieldName, int maxLength, String recordId,
+            String studyId) {
         if (!node.hasNonNull(fieldName)) {
             return null;
         }
-        return sanitizeString(node.get(fieldName).textValue(), fieldName, maxLength, recordId);
+        return sanitizeString(node.get(fieldName).textValue(), fieldName, maxLength, recordId, studyId);
     }
 
     /**
@@ -158,9 +162,12 @@ public class BridgeExporterUtil {
      *         max length of the column, null if the string can be unbounded
      * @param recordId
      *         record ID, for logging purposes
+     * @param studyId
+     *         study ID, for logging purposes
      * @return sanitized string
      */
-    public static String sanitizeString(String in, String fieldName, Integer maxLength, String recordId) {
+    public static String sanitizeString(String in, String fieldName, Integer maxLength, String recordId,
+            String studyId) {
         if (in == null) {
             return null;
         }
@@ -177,8 +184,8 @@ public class BridgeExporterUtil {
 
         // Check against max length, truncating and warning as necessary.
         if (maxLength != null && in.length() > maxLength) {
-            LOG.error("Truncating string for field " + fieldName + " in record " + recordId + ", original length " +
-                    in.length() + " to max length " + maxLength);
+            LOG.error("Truncating string for field " + fieldName + " in record " + recordId + " in study " + studyId +
+                    ", original length " + in.length() + " to max length " + maxLength);
             in = in.substring(0, maxLength);
         }
 

--- a/src/test/java/org/sagebionetworks/bridge/exporter/handler/HealthDataExportHandlerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/handler/HealthDataExportHandlerTest.java
@@ -299,7 +299,8 @@ public class HealthDataExportHandlerTest {
 
         // mock serializeToSynapseType() - We actually call through to the real method. Don't need to mock
         // uploadFromS3ToSynapseFileHandle() because we don't have file handles this time.
-        when(mockSynapseHelper.serializeToSynapseType(any(), any(), any(), any(), any(), any())).thenCallRealMethod();
+        when(mockSynapseHelper.serializeToSynapseType(any(), any(), any(), any(), any(), any(), any()))
+                .thenCallRealMethod();
 
         // Mock uploadFromS3ToSynapseFileHandle() for raw data attachment.
         when(mockSynapseHelper.uploadFromS3ToSynapseFileHandle(any(), eq(RAW_DATA_ATTACHMENT_ID),

--- a/src/test/java/org/sagebionetworks/bridge/exporter/handler/SynapseExportHandlerNewTableTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/handler/SynapseExportHandlerNewTableTest.java
@@ -242,7 +242,8 @@ public class SynapseExportHandlerNewTableTest {
 
         // mock serializeToSynapseType() - We actually call through to the real method. Don't need to mock
         // uploadFromS3ToSynapseFileHandle() because we don't have file handles this time.
-        when(mockSynapseHelper.serializeToSynapseType(any(), any(), any(), any(), any(), any())).thenCallRealMethod();
+        when(mockSynapseHelper.serializeToSynapseType(any(), any(), any(), any(), any(), any(), any()))
+                .thenCallRealMethod();
 
         // make subtask
         String recordJsonText = "{\n" +

--- a/src/test/java/org/sagebionetworks/bridge/exporter/handler/SynapseExportHandlerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/handler/SynapseExportHandlerTest.java
@@ -398,7 +398,8 @@ public class SynapseExportHandlerTest {
 
         // mock serializeToSynapseType() - We actually call through to the real method, but we mock out the underlying
         // uploadFromS3ToSynapseFileHandle() to avoid hitting real back-ends.
-        when(mockSynapseHelper.serializeToSynapseType(any(), any(), any(), any(), any(), any())).thenCallRealMethod();
+        when(mockSynapseHelper.serializeToSynapseType(any(), any(), any(), any(), any(), any(), any()))
+                .thenCallRealMethod();
 
         UploadFieldDefinition freeformAttachmentFieldDef = new UploadFieldDefinition().name(FREEFORM_FIELD_NAME)
                 .type(UploadFieldType.ATTACHMENT_V2);

--- a/src/test/java/org/sagebionetworks/bridge/exporter/synapse/SynapseHelperSerializeTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/synapse/SynapseHelperSerializeTest.java
@@ -37,6 +37,7 @@ public class SynapseHelperSerializeTest {
     private static final String TEST_PROJECT_ID = "test-project-id";
     private static final String TEST_RECORD_ID = "test-record-id";
     private static final String TEST_FIELD_NAME = "test-field-name";
+    private static final String TEST_STUDY_ID = "test-study-id";
 
     @DataProvider(name = "testSerializeProvider")
     public Object[][] testSerializeProvider() {
@@ -92,7 +93,7 @@ public class SynapseHelperSerializeTest {
 
         // serialize, which basically just copies the JSON text as is
         String retVal = new SynapseHelper().serializeToSynapseType(new Metrics(), MOCK_TEMP_DIR, TEST_PROJECT_ID,
-                TEST_RECORD_ID, fieldDefForType(UploadFieldType.INLINE_JSON_BLOB), originalNode);
+                TEST_RECORD_ID, TEST_STUDY_ID, fieldDefForType(UploadFieldType.INLINE_JSON_BLOB), originalNode);
 
         // parse back into JSON and compare
         JsonNode reparsedNode = DefaultObjectMapper.INSTANCE.readTree(retVal);
@@ -174,7 +175,7 @@ public class SynapseHelperSerializeTest {
         // execute
         Metrics metrics = new Metrics();
         String retVal = synapseHelper.serializeToSynapseType(metrics, MOCK_TEMP_DIR, TEST_PROJECT_ID, TEST_RECORD_ID,
-                attachmentFieldDef, new TextNode("dummy-attachment-id"));
+                TEST_STUDY_ID, attachmentFieldDef, new TextNode("dummy-attachment-id"));
         assertEquals(retVal, "dummy-filehandle-id");
 
         // Validate metrics
@@ -210,12 +211,12 @@ public class SynapseHelperSerializeTest {
 
         // Test case 1: attachment with sanitization
         String retVal1 = synapseHelper.serializeToSynapseType(metrics, MOCK_TEMP_DIR, TEST_PROJECT_ID, TEST_RECORD_ID,
-                fieldDef, new TextNode("my-large-text-attachment-id"));
+                TEST_STUDY_ID, fieldDef, new TextNode("my-large-text-attachment-id"));
         assertEquals(retVal1, "This is my large text attachment");
 
         // Test case 2: wrong type
         String retVal2 = synapseHelper.serializeToSynapseType(metrics, MOCK_TEMP_DIR, TEST_PROJECT_ID, TEST_RECORD_ID,
-                fieldDef, new LongNode(1234567890L));
+                TEST_STUDY_ID, fieldDef, new LongNode(1234567890L));
         assertNull(retVal2);
     }
 
@@ -226,7 +227,7 @@ public class SynapseHelperSerializeTest {
     private static void testHelper(Metrics metrics, UploadFieldDefinition fieldDef, JsonNode input,
             String expected) throws Exception {
         String retVal = new SynapseHelper().serializeToSynapseType(metrics, MOCK_TEMP_DIR, TEST_PROJECT_ID,
-                TEST_RECORD_ID, fieldDef, input);
+                TEST_RECORD_ID, TEST_STUDY_ID, fieldDef, input);
         assertEquals(retVal, expected);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/exporter/util/BridgeExporterUtilTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/util/BridgeExporterUtilTest.java
@@ -94,35 +94,40 @@ public class BridgeExporterUtilTest {
     public void sanitizeJsonValueNotObject() throws Exception {
         String jsonText = "\"not an object\"";
         JsonNode node = DefaultObjectMapper.INSTANCE.readTree(jsonText);
-        assertNull(BridgeExporterUtil.sanitizeJsonValue(node, "key", 100, "dummy-record"));
+        assertNull(BridgeExporterUtil.sanitizeJsonValue(node, "key", 100, "dummy-record",
+                "dummy-study"));
     }
 
     @Test
     public void sanitizeJsonValueNoValue() throws Exception {
         String jsonText = "{}";
         JsonNode node = DefaultObjectMapper.INSTANCE.readTree(jsonText);
-        assertNull(BridgeExporterUtil.sanitizeJsonValue(node, "key", 100, "dummy-record"));
+        assertNull(BridgeExporterUtil.sanitizeJsonValue(node, "key", 100, "dummy-record",
+                "dummy-study"));
     }
 
     @Test
     public void sanitizeJsonValueNullValue() throws Exception {
         String jsonText = "{\"key\":null}";
         JsonNode node = DefaultObjectMapper.INSTANCE.readTree(jsonText);
-        assertNull(BridgeExporterUtil.sanitizeJsonValue(node, "key", 100, "dummy-record"));
+        assertNull(BridgeExporterUtil.sanitizeJsonValue(node, "key", 100, "dummy-record",
+                "dummy-study"));
     }
 
     @Test
     public void sanitizeJsonValueNotString() throws Exception {
         String jsonText = "{\"key\":42}";
         JsonNode node = DefaultObjectMapper.INSTANCE.readTree(jsonText);
-        assertNull(BridgeExporterUtil.sanitizeJsonValue(node, "key", 100, "dummy-record"));
+        assertNull(BridgeExporterUtil.sanitizeJsonValue(node, "key", 100, "dummy-record",
+                "dummy-study"));
     }
 
     @Test
     public void sanitizeJsonValueNormalCase() throws Exception {
         String jsonText = "{\"key\":\"123\\t\\t\\t456\"}";
         JsonNode node = DefaultObjectMapper.INSTANCE.readTree(jsonText);
-        String out = BridgeExporterUtil.sanitizeJsonValue(node, "key", 5, "dummy-record");
+        String out = BridgeExporterUtil.sanitizeJsonValue(node, "key", 5, "dummy-record",
+                "dummy-study");
         assertEquals(out, "123 4");
     }
 
@@ -145,7 +150,8 @@ public class BridgeExporterUtilTest {
 
     @Test(dataProvider = "sanitizeStringDataProvider")
     public void sanitizeString(String in, Integer maxLength, String expected) {
-        assertEquals(BridgeExporterUtil.sanitizeString(in, "key", maxLength, "dummy-record"), expected);
+        assertEquals(BridgeExporterUtil.sanitizeString(in, "key", maxLength, "dummy-record",
+                "dummy-study"), expected);
     }
 
     @Test


### PR DESCRIPTION
We frequently get "truncating string" errors in studies that are in development. This adds study ID to the log message so we can filter them easily.