### PR TITLE
sanitize validation errors; fix null-pointer exception

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/exporter/synapse/ColumnDefinition.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/synapse/ColumnDefinition.java
@@ -1,10 +1,8 @@
 package org.sagebionetworks.bridge.exporter.synapse;
 
-import org.sagebionetworks.repo.model.table.ColumnType;
-
 public class ColumnDefinition  {
     private String name;
-    private Long maximumSize;
+    private Integer maximumSize;
     private TransferMethod transferMethod;
     private String ddbName;
     private boolean sanitize;
@@ -17,11 +15,11 @@ public class ColumnDefinition  {
         this.name = name;
     }
 
-    public Long getMaximumSize() {
+    public Integer getMaximumSize() {
         return maximumSize;
     }
 
-    public void setMaximumSize(Long maximumSize) {
+    public void setMaximumSize(Integer maximumSize) {
         this.maximumSize = maximumSize;
     }
 

--- a/src/main/java/org/sagebionetworks/bridge/exporter/util/BridgeExporterUtil.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/util/BridgeExporterUtil.java
@@ -115,7 +115,7 @@ public class BridgeExporterUtil {
      *         record ID, for logging purposes
      * @return sanitized DDB string value
      */
-    public static String sanitizeDdbValue(Item item, String fieldName, int maxLength, String recordId) {
+    public static String sanitizeDdbValue(Item item, String fieldName, Integer maxLength, String recordId) {
         String value = item.getString(fieldName);
         String studyId = item.getString("studyId");
         return sanitizeString(value, fieldName, maxLength, recordId, studyId);
@@ -219,7 +219,13 @@ public class BridgeExporterUtil {
             ColumnModel columnModel = new ColumnModel();
             columnModel.setName(columnDefinition.getName());
             columnModel.setColumnType(columnDefinition.getTransferMethod().getColumnType());
-            columnModel.setMaximumSize(columnDefinition.getMaximumSize());
+
+            // For some reason, ColumnModel.maximumSize is a long, but we have ints. It can't ever be more than 1000
+            // anyway.
+            if (columnDefinition.getMaximumSize() != null) {
+                columnModel.setMaximumSize(columnDefinition.getMaximumSize().longValue());
+            }
+
             columnListBuilder.add(columnModel);
         }
 
@@ -234,7 +240,7 @@ public class BridgeExporterUtil {
 
             String valueToAdd;
             if (columnDefinition.getSanitize()) {
-                valueToAdd = sanitizeDdbValue(record, ddbName, columnDefinition.getMaximumSize().intValue(), recordId);
+                valueToAdd = sanitizeDdbValue(record, ddbName, columnDefinition.getMaximumSize(), recordId);
             } else {
                 TransferMethod transferMethod = columnDefinition.getTransferMethod();
                 valueToAdd = transferMethod.transfer(ddbName, record);

--- a/src/main/resources/ColumnDefinition.json
+++ b/src/main/resources/ColumnDefinition.json
@@ -33,6 +33,7 @@
   },
   {
     "name": "validationErrors",
-    "transferMethod": "LARGETEXT"
+    "transferMethod": "LARGETEXT",
+    "sanitize": true
   }
 ]

--- a/src/test/java/org/sagebionetworks/bridge/exporter/handler/SynapseExportHandlerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/handler/SynapseExportHandlerTest.java
@@ -564,14 +564,14 @@ public class SynapseExportHandlerTest {
 
         ColumnDefinition healthCodeDefinition = new ColumnDefinition();
         healthCodeDefinition.setName("healthCode");
-        healthCodeDefinition.setMaximumSize(36L);
+        healthCodeDefinition.setMaximumSize(36);
         healthCodeDefinition.setTransferMethod(TransferMethod.STRING);
         columnDefinitionsBuilder.add(healthCodeDefinition);
 
         ColumnDefinition externalIdDefinition = new ColumnDefinition();
         externalIdDefinition.setName("externalId");
         externalIdDefinition.setDdbName("userExternalId");
-        externalIdDefinition.setMaximumSize(128L);
+        externalIdDefinition.setMaximumSize(128);
         externalIdDefinition.setTransferMethod(TransferMethod.STRING);
         externalIdDefinition.setSanitize(true);
         columnDefinitionsBuilder.add(externalIdDefinition);
@@ -579,7 +579,7 @@ public class SynapseExportHandlerTest {
         ColumnDefinition dataGroupsDefinition = new ColumnDefinition();
         dataGroupsDefinition.setName("dataGroups");
         dataGroupsDefinition.setDdbName("userDataGroups");
-        dataGroupsDefinition.setMaximumSize(100L);
+        dataGroupsDefinition.setMaximumSize(100);
         dataGroupsDefinition.setTransferMethod(TransferMethod.STRINGSET);
         columnDefinitionsBuilder.add(dataGroupsDefinition);
 
@@ -590,7 +590,7 @@ public class SynapseExportHandlerTest {
 
         ColumnDefinition userSharingScopeDefinition = new ColumnDefinition();
         userSharingScopeDefinition.setName("userSharingScope");
-        userSharingScopeDefinition.setMaximumSize(48L);
+        userSharingScopeDefinition.setMaximumSize(48);
         userSharingScopeDefinition.setTransferMethod(TransferMethod.STRING);
         columnDefinitionsBuilder.add(userSharingScopeDefinition);
 

--- a/src/test/java/org/sagebionetworks/bridge/exporter/synapse/ColumnDefinitionTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/synapse/ColumnDefinitionTest.java
@@ -16,7 +16,7 @@ import static org.testng.Assert.assertEquals;
 public class ColumnDefinitionTest {
     private static final String TEST_NAME = "healthCode";
     private static final ColumnType TEST_COLUMN_TYPE = ColumnType.STRING;
-    private static final Long TEST_MAXIMUM_SIZE = 36L;
+    private static final int TEST_MAXIMUM_SIZE = 36;
     private static final TransferMethod TEST_TRANSFER_METHOD = TransferMethod.STRING;
     private static final String TEST_DDB_NAME = "healthCode";
     private static final boolean TEST_SANITIZE = true;
@@ -38,7 +38,7 @@ public class ColumnDefinitionTest {
         assertEquals(value.getName(), TEST_NAME);
         assertEquals(value.getDdbName(), TEST_DDB_NAME);
         assertEquals(value.getTransferMethod().getColumnType(), TEST_COLUMN_TYPE);
-        assertEquals(value.getMaximumSize(), TEST_MAXIMUM_SIZE);
+        assertEquals(value.getMaximumSize().intValue(), TEST_MAXIMUM_SIZE);
         assertEquals(value.getSanitize(), TEST_SANITIZE);
         assertEquals(value.getTransferMethod(), TEST_TRANSFER_METHOD);
     }
@@ -59,7 +59,7 @@ public class ColumnDefinitionTest {
 
         assertEquals(node.get("name").textValue(), TEST_NAME);
         assertEquals(node.get("ddbName").textValue(), TEST_DDB_NAME);
-        assertEquals(node.get("maximumSize").longValue(), TEST_MAXIMUM_SIZE.longValue());
+        assertEquals(node.get("maximumSize").intValue(), TEST_MAXIMUM_SIZE);
         assertEquals(node.get("sanitize").booleanValue(), TEST_SANITIZE);
         assertEquals(node.get("transferMethod").textValue(), TEST_TRANSFER_METHOD.toString());
 

--- a/src/test/java/org/sagebionetworks/bridge/exporter/util/BridgeExporterUtilTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/util/BridgeExporterUtilTest.java
@@ -91,6 +91,13 @@ public class BridgeExporterUtilTest {
     }
 
     @Test
+    public void sanitizeDdbValueNoMaxLength() {
+        Item item = new Item().withString("key", "1234567890");
+        String out = BridgeExporterUtil.sanitizeDdbValue(item, "key", null, "dummy-record");
+        assertEquals(out, "1234567890");
+    }
+
+    @Test
     public void sanitizeJsonValueNotObject() throws Exception {
         String jsonText = "\"not an object\"";
         JsonNode node = DefaultObjectMapper.INSTANCE.readTree(jsonText);
@@ -194,12 +201,12 @@ public class BridgeExporterUtilTest {
         ColumnDefinition stringDef = new ColumnDefinition();
         stringDef.setName("my-string");
         stringDef.setTransferMethod(TransferMethod.STRING);
-        stringDef.setMaximumSize(42L);
+        stringDef.setMaximumSize(42);
 
         ColumnDefinition stringSetDef = new ColumnDefinition();
         stringSetDef.setName("my-string-set");
         stringSetDef.setTransferMethod(TransferMethod.STRINGSET);
-        stringSetDef.setMaximumSize(128L);
+        stringSetDef.setMaximumSize(128);
 
         ColumnDefinition dateDef = new ColumnDefinition();
         dateDef.setName("my-date");
@@ -217,17 +224,19 @@ public class BridgeExporterUtilTest {
 
         assertEquals(columnModelList.get(0).getName(), "my-string");
         assertEquals(columnModelList.get(0).getColumnType(), ColumnType.STRING);
-        assertEquals(columnModelList.get(0).getMaximumSize().longValue(), 42);
+        assertEquals(columnModelList.get(0).getMaximumSize().intValue(), 42);
 
         assertEquals(columnModelList.get(1).getName(), "my-string-set");
         assertEquals(columnModelList.get(1).getColumnType(), ColumnType.STRING);
-        assertEquals(columnModelList.get(1).getMaximumSize().longValue(), 128);
+        assertEquals(columnModelList.get(1).getMaximumSize().intValue(), 128);
 
         assertEquals(columnModelList.get(2).getName(), "my-date");
         assertEquals(columnModelList.get(2).getColumnType(), ColumnType.DATE);
+        assertNull(columnModelList.get(2).getMaximumSize());
 
         assertEquals(columnModelList.get(3).getName(), "my-large-text");
         assertEquals(columnModelList.get(3).getColumnType(), ColumnType.LARGETEXT);
+        assertNull(columnModelList.get(3).getMaximumSize());
     }
 
     @Test
@@ -236,12 +245,12 @@ public class BridgeExporterUtilTest {
         ColumnDefinition stringDef = new ColumnDefinition();
         stringDef.setName("my-string");
         stringDef.setTransferMethod(TransferMethod.STRING);
-        stringDef.setMaximumSize(42L);
+        stringDef.setMaximumSize(42);
 
         ColumnDefinition stringSetDef = new ColumnDefinition();
         stringSetDef.setName("my-string-set");
         stringSetDef.setTransferMethod(TransferMethod.STRINGSET);
-        stringSetDef.setMaximumSize(128L);
+        stringSetDef.setMaximumSize(128);
 
         ColumnDefinition dateDef = new ColumnDefinition();
         dateDef.setName("my-date");
@@ -255,22 +264,27 @@ public class BridgeExporterUtilTest {
         renamedColumnDef.setName("renamed-column");
         renamedColumnDef.setDdbName("ddb-column");
         renamedColumnDef.setTransferMethod(TransferMethod.STRING);
-        renamedColumnDef.setMaximumSize(24L);
+        renamedColumnDef.setMaximumSize(24);
 
         ColumnDefinition sanitizeMeDef = new ColumnDefinition();
         sanitizeMeDef.setName("sanitize-me");
         sanitizeMeDef.setTransferMethod(TransferMethod.STRING);
-        sanitizeMeDef.setMaximumSize(24L);
+        sanitizeMeDef.setMaximumSize(24);
         sanitizeMeDef.setSanitize(true);
+
+        ColumnDefinition sanitizedLargeTextDef = new ColumnDefinition();
+        sanitizedLargeTextDef.setName("sanitized-large-text");
+        sanitizedLargeTextDef.setTransferMethod(TransferMethod.LARGETEXT);
+        sanitizedLargeTextDef.setSanitize(true);
 
         ColumnDefinition truncateMeDef = new ColumnDefinition();
         truncateMeDef.setName("truncate-me");
         truncateMeDef.setTransferMethod(TransferMethod.STRING);
-        truncateMeDef.setMaximumSize(3L);
+        truncateMeDef.setMaximumSize(3);
         truncateMeDef.setSanitize(true);
 
         List<ColumnDefinition> columnDefinitionList = ImmutableList.of(stringDef, stringSetDef, dateDef, largeTextDef,
-                renamedColumnDef, sanitizeMeDef, truncateMeDef);
+                renamedColumnDef, sanitizeMeDef, sanitizedLargeTextDef, truncateMeDef);
 
         // Set up DDB record for test.
         Item ddbRecord = new Item()
@@ -280,19 +294,21 @@ public class BridgeExporterUtilTest {
                 .withString("my-large-text", "my-large-text-value")
                 .withString("ddb-column", "ddb-column-value")
                 .withString("sanitize-me", "<b><i><u>Sanitize me!</b></i></u>")
+                .withString("sanitized-large-text", "quoted \"value\"")
                 .withString("truncate-me", "truncate-me-value");
 
         // execute and validate
         Map<String, String> rowMap = new HashMap<>();
         BridgeExporterUtil.getRowValuesFromRecordBasedOnColumnDefinition(rowMap, ddbRecord, columnDefinitionList,
                 "record-id");
-        assertEquals(rowMap.size(), 7);
+        assertEquals(rowMap.size(), 8);
         assertEquals("my-string-value", rowMap.get("my-string"));
         assertEquals("val1,val2", rowMap.get("my-string-set"));
         assertEquals("1234567890", rowMap.get("my-date"));
         assertEquals("my-large-text-value", rowMap.get("my-large-text"));
         assertEquals("ddb-column-value", rowMap.get("renamed-column"));
         assertEquals("Sanitize me!", rowMap.get("sanitize-me"));
+        assertEquals("quoted \\\"value\\\"", rowMap.get("sanitized-large-text"));
         assertEquals("tru", rowMap.get("truncate-me"));
     }
 
@@ -315,7 +331,7 @@ public class BridgeExporterUtilTest {
 
         ColumnDefinition testDefinition1 = new ColumnDefinition();
         testDefinition1.setName(testStringName);
-        testDefinition1.setMaximumSize(36L);
+        testDefinition1.setMaximumSize(36);
         testDefinition1.setTransferMethod(TransferMethod.STRING);
         columnDefinitionBuilder.add(testDefinition1);
 


### PR DESCRIPTION
We currently don't sanitize validation errors. This includes stripping away newlines, tabs, and escaping strings. This leads to really weird things happening in Synapse when we have unescaped quotes.