### PR TITLE
Use CSVWriter Library

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/exporter/handler/SynapseExportHandler.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/handler/SynapseExportHandler.java
@@ -3,7 +3,7 @@ package org.sagebionetworks.bridge.exporter.handler;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.PrintWriter;
+import java.io.Writer;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -139,10 +139,10 @@ public abstract class SynapseExportHandler extends ExportHandler {
             // create TSV and writer
             FileHelper fileHelper = getManager().getFileHelper();
             File tsvFile = fileHelper.newFile(task.getTmpDir(), getDdbTableKeyValue() + ".tsv");
-            PrintWriter tsvWriter = new PrintWriter(fileHelper.getWriter(tsvFile));
+            Writer fileWriter = fileHelper.getWriter(tsvFile);
 
             // create TSV info
-            tsvInfo = new TsvInfo(columnNameList, tsvFile, tsvWriter);
+            tsvInfo = new TsvInfo(columnNameList, tsvFile, fileWriter);
         } catch (BridgeExporterException | FileNotFoundException | SchemaNotFoundException | SynapseException ex) {
             LOG.error("Error initializing TSV for table " + getDdbTableKeyValue() + ": " + ex.getMessage(), ex);
             tsvInfo = new TsvInfo(ex);

--- a/src/test/java/org/sagebionetworks/bridge/exporter/handler/HealthDataExportHandlerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/handler/HealthDataExportHandlerTest.java
@@ -542,7 +542,7 @@ public class HealthDataExportHandlerTest {
                 "metadata.when.timezone", "metadata.foo", "metadata.bar", "record.foo", "record.baz",
                 HealthDataExportHandler.COLUMN_NAME_RAW_DATA);
         SynapseExportHandlerTest.validateTsvRow(tsvLineList.get(1), "false", "false", "true", "None of the above",
-                String.valueOf(whenMillis), "+0900", "37", "metadata-bar", "foo-value", "baz-value", "");
+                String.valueOf(whenMillis), "+0900", "37", "metadata-bar", "foo-value", "baz-value", null);
 
         // This test doesn't upload any raw data.
         verify(mockSynapseHelper, never()).uploadFromS3ToSynapseFileHandle(any(), any(), any());

--- a/src/test/java/org/sagebionetworks/bridge/exporter/handler/PhoneAppVersionInfoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/handler/PhoneAppVersionInfoTest.java
@@ -38,12 +38,12 @@ public class PhoneAppVersionInfoTest {
     @Test
     public void sanitizeFields() {
         String metadataText = "{\n" +
-                "   \"appVersion\":\"Bridge-EX\\t\\t2.0\",\n" +
-                "   \"phoneInfo\":\"Extra\\t\\ttabs\"\n" +
+                "   \"appVersion\":\"<p>Bridge-EX 2.0</p>\",\n" +
+                "   \"phoneInfo\":\"<b>formatting tag</b>\"\n" +
                 "}";
         Item record = new Item().withString("id", "test-record-id").withString("metadata", metadataText);
         PhoneAppVersionInfo info = PhoneAppVersionInfo.fromRecord(record);
         assertEquals(info.getAppVersion(), "Bridge-EX 2.0");
-        assertEquals(info.getPhoneInfo(), "Extra tabs");
+        assertEquals(info.getPhoneInfo(), "formatting tag");
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/exporter/handler/SynapseExportHandlerNewTableTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/handler/SynapseExportHandlerNewTableTest.java
@@ -261,7 +261,7 @@ public class SynapseExportHandlerNewTableTest {
         assertEquals(tsvLineList.size(), 2);
         SynapseExportHandlerTest.validateTsvHeaders(tsvLineList.get(0), "foo", "bar",
                 HealthDataExportHandler.COLUMN_NAME_RAW_DATA);
-        SynapseExportHandlerTest.validateTsvRow(tsvLineList.get(1), "This is a string.", "42", "");
+        SynapseExportHandlerTest.validateTsvRow(tsvLineList.get(1), "This is a string.", "42", null);
 
         validateTableCreation(handler);
     }

--- a/src/test/java/org/sagebionetworks/bridge/exporter/synapse/SynapseHelperSerializeTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/synapse/SynapseHelperSerializeTest.java
@@ -88,7 +88,7 @@ public class SynapseHelperSerializeTest {
     @Test
     public void inlineJsonBlob() throws Exception {
         // based on real JSON blobs
-        String jsonText = "[1, 3, 5, 7]";
+        String jsonText = "[1, 3, 5, 7, \"this is a string\"]";
         JsonNode originalNode = DefaultObjectMapper.INSTANCE.readTree(jsonText);
 
         // serialize, which basically just copies the JSON text as is
@@ -98,11 +98,12 @@ public class SynapseHelperSerializeTest {
         // parse back into JSON and compare
         JsonNode reparsedNode = DefaultObjectMapper.INSTANCE.readTree(retVal);
         assertTrue(reparsedNode.isArray());
-        assertEquals(reparsedNode.size(), 4);
+        assertEquals(reparsedNode.size(), 5);
         assertEquals(reparsedNode.get(0).intValue(), 1);
         assertEquals(reparsedNode.get(1).intValue(), 3);
         assertEquals(reparsedNode.get(2).intValue(), 5);
         assertEquals(reparsedNode.get(3).intValue(), 7);
+        assertEquals(reparsedNode.get(4).textValue(), "this is a string");
     }
 
     @DataProvider(name = "stringTypeProvider")

--- a/src/test/java/org/sagebionetworks/bridge/exporter/util/BridgeExporterUtilTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/util/BridgeExporterUtilTest.java
@@ -85,7 +85,7 @@ public class BridgeExporterUtilTest {
 
     @Test
     public void sanitizeDdbValueNormalCase() {
-        Item item = new Item().withString("key", "123\t\t\t456");
+        Item item = new Item().withString("key", "<p>123 456</p>");
         String out = BridgeExporterUtil.sanitizeDdbValue(item, "key", 5, "dummy-record");
         assertEquals(out, "123 4");
     }
@@ -131,7 +131,7 @@ public class BridgeExporterUtilTest {
 
     @Test
     public void sanitizeJsonValueNormalCase() throws Exception {
-        String jsonText = "{\"key\":\"123\\t\\t\\t456\"}";
+        String jsonText = "{\"key\":\"<p>123 456</p>\"}";
         JsonNode node = DefaultObjectMapper.INSTANCE.readTree(jsonText);
         String out = BridgeExporterUtil.sanitizeJsonValue(node, "key", 5, "dummy-record",
                 "dummy-study");
@@ -147,9 +147,9 @@ public class BridgeExporterUtilTest {
                 { "<b>bold text</b>", 100, "bold text" },
                 { "imbalanced</i> <p>tags", 100, "imbalanced tags" },
                 { "newlines\n\n\nCRLF\r\ntabs\t\ttabs", 1000, "newlines CRLF tabs tabs" },
-                { "quote\"quote", 100, "quote\\\"quote" },
-                { "escaped\\\"quote", 100, "escaped\\\\\\\"quote" },
-                { "[ \"inline\", \"json\", \"blob\" ]", 100, "[ \\\"inline\\\", \\\"json\\\", \\\"blob\\\" ]" },
+                { "quote\"quote", 100, "quote\"quote" },
+                { "escaped\\\"quote", 100, "escaped\\\"quote" },
+                { "[ \"inline\", \"json\", \"blob\" ]", 100, "[ \"inline\", \"json\", \"blob\" ]" },
                 { "1234567890", 4, "1234" },
                 { "stuff", null, "stuff" },
         };
@@ -294,7 +294,7 @@ public class BridgeExporterUtilTest {
                 .withString("my-large-text", "my-large-text-value")
                 .withString("ddb-column", "ddb-column-value")
                 .withString("sanitize-me", "<b><i><u>Sanitize me!</b></i></u>")
-                .withString("sanitized-large-text", "quoted \"value\"")
+                .withString("sanitized-large-text", "<b>formatted string</b>")
                 .withString("truncate-me", "truncate-me-value");
 
         // execute and validate
@@ -308,7 +308,7 @@ public class BridgeExporterUtilTest {
         assertEquals("my-large-text-value", rowMap.get("my-large-text"));
         assertEquals("ddb-column-value", rowMap.get("renamed-column"));
         assertEquals("Sanitize me!", rowMap.get("sanitize-me"));
-        assertEquals("quoted \\\"value\\\"", rowMap.get("sanitized-large-text"));
+        assertEquals("formatted string", rowMap.get("sanitized-large-text"));
         assertEquals("tru", rowMap.get("truncate-me"));
     }
 

--- a/src/test/java/org/sagebionetworks/bridge/exporter/worker/ExportTaskTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/worker/ExportTaskTest.java
@@ -6,7 +6,7 @@ import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
 
 import java.io.File;
-import java.io.PrintWriter;
+import java.io.Writer;
 import java.util.Queue;
 import java.util.Set;
 
@@ -143,6 +143,6 @@ public class ExportTaskTest {
 
     private static TsvInfo createTsvInfo() {
         // We don't actually use the TSV for anything, so it's safe to stick an empty list and 2 mocks in here.
-        return new TsvInfo(ImmutableList.of(), mock(File.class), mock(PrintWriter.class));
+        return new TsvInfo(ImmutableList.of(), mock(File.class), mock(Writer.class));
     }
 }


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/BRIDGE-2369

Instead of manually creating our own TSVs, we should use an existing CSVWriter library. This means we're less likely to hit weird TSV formatting errors.

Testing done:
* mvn verify (unit tests, FindBugs, Jacoco test coverage)
* integ tests
* manually tested newlines, carriage returns, tabs, quotes, and escapes in every type of field and metadata