### PR TITLE
Add BridgeStaff and BridgeAdmin to table permissions

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/exporter/synapse/SynapseHelper.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/synapse/SynapseHelper.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.SetMultimap;
 import com.google.common.util.concurrent.RateLimiter;
 import com.jcabi.aspects.RetryOnFailure;
+import org.apache.commons.lang3.StringUtils;
 import org.sagebionetworks.client.SynapseClient;
 import org.sagebionetworks.client.exceptions.SynapseException;
 import org.sagebionetworks.client.exceptions.SynapseResultNotReadyException;
@@ -67,9 +68,13 @@ public class SynapseHelper {
     static final String CONFIG_KEY_SYNAPSE_RATE_LIMIT_PER_SECOND = "synapse.rate.limit.per.second";
     static final String CONFIG_KEY_SYNAPSE_GET_COLUMN_MODELS_RATE_LIMIT_PER_MINUTE =
             "synapse.get.column.models.rate.limit.per.minute";
+    static final String CONFIG_KEY_TEAM_BRIDGE_ADMIN = "team.bridge.admin";
+    static final String CONFIG_KEY_TEAM_BRIDGE_STAFF = "team.bridge.staff";
 
     // Shared constants.
-    public static final Set<ACCESS_TYPE> ACCESS_TYPE_ALL = ImmutableSet.copyOf(ACCESS_TYPE.values());
+    public static final Set<ACCESS_TYPE> ACCESS_TYPE_ADMIN = ImmutableSet.of(ACCESS_TYPE.READ, ACCESS_TYPE.DOWNLOAD,
+            ACCESS_TYPE.UPDATE, ACCESS_TYPE.DELETE, ACCESS_TYPE.CREATE, ACCESS_TYPE.CHANGE_PERMISSIONS,
+            ACCESS_TYPE.CHANGE_SETTINGS, ACCESS_TYPE.MODERATE);
     public static final Set<ACCESS_TYPE> ACCESS_TYPE_READ = ImmutableSet.of(ACCESS_TYPE.READ, ACCESS_TYPE.DOWNLOAD);
     public static final String DDB_TABLE_SYNAPSE_META_TABLES = "SynapseMetaTables";
     public static final String DDB_KEY_TABLE_NAME = "tableName";
@@ -168,6 +173,8 @@ public class SynapseHelper {
     private int asyncIntervalMillis;
     private int asyncTimeoutLoops;
     private String attachmentBucket;
+    private long bridgeAdminTeamId;
+    private long bridgeStaffTeamId;
 
     // Spring helpers
     private FileHelper fileHelper;
@@ -188,12 +195,31 @@ public class SynapseHelper {
         this.asyncTimeoutLoops = config.getInt(CONFIG_KEY_SYNAPSE_ASYNC_TIMEOUT_LOOPS);
         this.attachmentBucket = config.get(BridgeExporterUtil.CONFIG_KEY_ATTACHMENT_S3_BUCKET);
 
+        String bridgeAdminTeamIdStr = config.get(CONFIG_KEY_TEAM_BRIDGE_ADMIN);
+        if (StringUtils.isNotBlank(bridgeAdminTeamIdStr)) {
+            this.bridgeAdminTeamId = Long.parseLong(bridgeAdminTeamIdStr);
+        }
+        String bridgeStaffTeamIdStr = config.get(CONFIG_KEY_TEAM_BRIDGE_STAFF);
+        if (StringUtils.isNotBlank(bridgeStaffTeamIdStr)) {
+            this.bridgeStaffTeamId = Long.parseLong(bridgeStaffTeamIdStr);
+        }
+
         int rateLimitPerSecond = config.getInt(CONFIG_KEY_SYNAPSE_RATE_LIMIT_PER_SECOND);
         rateLimiter.setRate(rateLimitPerSecond);
 
         int getColumnModelsRateLimitPerMinute = config.getInt(
                 CONFIG_KEY_SYNAPSE_GET_COLUMN_MODELS_RATE_LIMIT_PER_MINUTE);
         getColumnModelsRateLimiter.setRate(getColumnModelsRateLimitPerMinute / 60.0);
+    }
+
+    // Package-scoped for unit tests.
+    void setBridgeAdminTeamId(long bridgeAdminTeamId) {
+        this.bridgeAdminTeamId = bridgeAdminTeamId;
+    }
+
+    // Package-scoped for unit tests.
+    void setBridgeStaffTeamId(long bridgeStaffTeamId) {
+        this.bridgeStaffTeamId = bridgeStaffTeamId;
     }
 
     /** File helper, used when we need to create a temporary file for downloads and uploads. */
@@ -780,19 +806,38 @@ public class SynapseHelper {
         String synapseTableId = createdTable.getId();
 
         // create ACLs
+        // There are 4 ACLs that need to be added.
+        // 1. BridgeExporter (admin)
+        // 2. Data Access team (read-only)
+        // 3. BridgeAdmin team (admin)
+        // 4. BridgeStaff team (read-only)
         // ResourceAccess is a mutable object, but the Synapse API takes them in a Set. This is a little weird.
         // IMPORTANT: Do not modify ResourceAccess objects after adding them to the set. This will break the set.
         Set<ResourceAccess> resourceAccessSet = new HashSet<>();
 
+        // BridgeExporter
         ResourceAccess exporterOwnerAccess = new ResourceAccess();
         exporterOwnerAccess.setPrincipalId(principalId);
-        exporterOwnerAccess.setAccessType(ACCESS_TYPE_ALL);
+        exporterOwnerAccess.setAccessType(ACCESS_TYPE_ADMIN);
         resourceAccessSet.add(exporterOwnerAccess);
 
+        // Data Access Team
         ResourceAccess dataAccessTeamAccess = new ResourceAccess();
         dataAccessTeamAccess.setPrincipalId(dataAccessTeamId);
         dataAccessTeamAccess.setAccessType(ACCESS_TYPE_READ);
         resourceAccessSet.add(dataAccessTeamAccess);
+
+        // BridgeAdmin Team
+        ResourceAccess bridgeAdminAccess = new ResourceAccess();
+        bridgeAdminAccess.setPrincipalId(bridgeAdminTeamId);
+        bridgeAdminAccess.setAccessType(ACCESS_TYPE_ADMIN);
+        resourceAccessSet.add(bridgeAdminAccess);
+
+        // BridgeStaff Team
+        ResourceAccess bridgeStaffAccess = new ResourceAccess();
+        bridgeStaffAccess.setPrincipalId(bridgeStaffTeamId);
+        bridgeStaffAccess.setAccessType(ACCESS_TYPE_READ);
+        resourceAccessSet.add(bridgeStaffAccess);
 
         AccessControlList acl = new AccessControlList();
         acl.setId(synapseTableId);

--- a/src/main/resources/BridgeExporter.conf
+++ b/src/main/resources/BridgeExporter.conf
@@ -41,6 +41,11 @@ dev.s3.notification.sqs.queue.url=https://sqs.us-east-1.amazonaws.com/6492322506
 uat.s3.notification.sqs.queue.url=https://sqs.us-east-1.amazonaws.com/649232250620/Bridge-UploadComplete-Notification-uat
 prod.s3.notification.sqs.queue.url=https://sqs.us-east-1.amazonaws.com/649232250620/Bridge-UploadComplete-Notification-prod
 
+team.bridge.admin = 3388390
+team.bridge.staff = 3388389
+prod.team.bridge.admin = 3388392
+prod.team.bridge.staff = 3388391
+
 local.record.id.override.bucket=org-sagebridge-exporter-recordids-local
 dev.record.id.override.bucket=org-sagebridge-exporter-recordids-develop
 uat.record.id.override.bucket=org-sagebridge-exporter-recordids-uat

--- a/src/test/java/org/sagebionetworks/bridge/exporter/synapse/SynapseHelperTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/synapse/SynapseHelperTest.java
@@ -45,6 +45,11 @@ import org.sagebionetworks.bridge.rest.model.UploadFieldType;
 
 @SuppressWarnings({ "unchecked", "rawtypes" })
 public class SynapseHelperTest {
+    private static final long BRIDGE_ADMIN_TEAM_ID = 1357L;
+    private static final long BRIDGE_STAFF_TEAM_ID = 2468L;
+    private static final long DATA_ACCESS_TEAM_ID = 1234L;
+    private static final long PRINCIPAL_ID = 5678L;
+
     @DataProvider
     public Object[][] maxLengthTestDataProvider() {
         // { fieldDef, expectedMaxLength }
@@ -298,6 +303,10 @@ public class SynapseHelperTest {
         // imeplementations of create column, create table, and create ACLs.
         SynapseHelper synapseHelper = spy(new SynapseHelper());
 
+        // Set Bridge Admin and Staff Team IDs.
+        synapseHelper.setBridgeAdminTeamId(BRIDGE_ADMIN_TEAM_ID);
+        synapseHelper.setBridgeStaffTeamId(BRIDGE_STAFF_TEAM_ID);
+
         // mock create column call - We only care about the IDs, so don't bother instantiating the rest.
         ColumnModel createdFooColumn = new ColumnModel();
         createdFooColumn.setId("foo-col-id");
@@ -323,8 +332,8 @@ public class SynapseHelperTest {
         doReturn(new AccessControlList()).when(synapseHelper).createAclWithRetry(aclCaptor.capture());
 
         // execute and validate
-        String retVal = synapseHelper.createTableWithColumnsAndAcls(columnList, /*data access team ID*/ 1234,
-                /*principal ID*/ 5678, "test-project", "My Table");
+        String retVal = synapseHelper.createTableWithColumnsAndAcls(columnList, DATA_ACCESS_TEAM_ID, PRINCIPAL_ID,
+                "test-project", "My Table");
         assertEquals(retVal, "test-table");
 
         // validate tableCaptor
@@ -338,17 +347,27 @@ public class SynapseHelperTest {
         assertEquals(acl.getId(), "test-table");
 
         Set<ResourceAccess> resourceAccessSet = acl.getResourceAccess();
-        assertEquals(resourceAccessSet.size(), 2);
+        assertEquals(resourceAccessSet.size(), 4);
 
         ResourceAccess exporterOwnerAccess = new ResourceAccess();
-        exporterOwnerAccess.setPrincipalId(5678L);
-        exporterOwnerAccess.setAccessType(SynapseHelper.ACCESS_TYPE_ALL);
+        exporterOwnerAccess.setPrincipalId(PRINCIPAL_ID);
+        exporterOwnerAccess.setAccessType(SynapseHelper.ACCESS_TYPE_ADMIN);
         assertTrue(resourceAccessSet.contains(exporterOwnerAccess));
 
         ResourceAccess dataAccessTeamAccess = new ResourceAccess();
-        dataAccessTeamAccess.setPrincipalId(1234L);
+        dataAccessTeamAccess.setPrincipalId(DATA_ACCESS_TEAM_ID);
         dataAccessTeamAccess.setAccessType(SynapseHelper.ACCESS_TYPE_READ);
         assertTrue(resourceAccessSet.contains(dataAccessTeamAccess));
+
+        ResourceAccess bridgeAdminTeamAccess = new ResourceAccess();
+        bridgeAdminTeamAccess.setPrincipalId(BRIDGE_ADMIN_TEAM_ID);
+        bridgeAdminTeamAccess.setAccessType(SynapseHelper.ACCESS_TYPE_ADMIN);
+        assertTrue(resourceAccessSet.contains(bridgeAdminTeamAccess));
+
+        ResourceAccess bridgeStaffTeamAccess = new ResourceAccess();
+        bridgeStaffTeamAccess.setPrincipalId(BRIDGE_STAFF_TEAM_ID);
+        bridgeStaffTeamAccess.setAccessType(SynapseHelper.ACCESS_TYPE_READ);
+        assertTrue(resourceAccessSet.contains(bridgeStaffTeamAccess));
     }
 
     @Test


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/BRIDGE-2396
https://sagebionetworks.jira.com/browse/BRIDGE-2348

Creates new permission groups as per https://sagebionetworks.jira.com/wiki/spaces/BRIDGE/pages/765034497/Ad-Hoc+Data+Change+Policy

Testing done:
* mvn verify (unit tests, FindBugs, Jacoco test coverage)
* deleted tables from test project, ran integration tests, verified permissions on newly created tables