### PR TITLE
Update SynapseJavaClient

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <dependency>
             <groupId>org.sagebionetworks</groupId>
             <artifactId>synapseJavaClient</artifactId>
-            <version>199.0</version>
+            <version>268.02</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/java/org/sagebionetworks/bridge/exporter/dynamo/StudyInfo.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/dynamo/StudyInfo.java
@@ -1,6 +1,6 @@
 package org.sagebionetworks.bridge.exporter.dynamo;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * This class encapsulates study config for Bridge-EX. Note that once the Synapse tables are created and the project is

--- a/src/main/java/org/sagebionetworks/bridge/exporter/handler/AppVersionExportHandler.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/handler/AppVersionExportHandler.java
@@ -6,7 +6,7 @@ import java.util.Map;
 
 import com.amazonaws.services.dynamodbv2.document.Item;
 import com.google.common.collect.ImmutableList;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.sagebionetworks.repo.model.table.ColumnModel;
 import org.sagebionetworks.repo.model.table.ColumnType;
 

--- a/src/main/java/org/sagebionetworks/bridge/exporter/handler/IosSurveyExportHandler.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/handler/IosSurveyExportHandler.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 
 import com.amazonaws.services.dynamodbv2.document.Item;
 import com.fasterxml.jackson.databind.JsonNode;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/org/sagebionetworks/bridge/exporter/handler/PhoneAppVersionInfo.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/handler/PhoneAppVersionInfo.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 
 import com.amazonaws.services.dynamodbv2.document.Item;
 import com.fasterxml.jackson.databind.JsonNode;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/org/sagebionetworks/bridge/exporter/helper/ExportHelper.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/helper/ExportHelper.java
@@ -15,7 +15,7 @@ import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableMap;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.codec.digest.DigestUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.sagebionetworks.repo.model.table.ColumnType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/org/sagebionetworks/bridge/exporter/record/RecordFilterHelper.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/record/RecordFilterHelper.java
@@ -3,7 +3,7 @@ package org.sagebionetworks.bridge.exporter.record;
 import java.util.Set;
 
 import com.amazonaws.services.dynamodbv2.document.Item;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/java/org/sagebionetworks/bridge/exporter/record/RecordIdSourceFactory.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/record/RecordIdSourceFactory.java
@@ -10,7 +10,7 @@ import com.amazonaws.services.dynamodbv2.document.Index;
 import com.amazonaws.services.dynamodbv2.document.Item;
 import com.amazonaws.services.dynamodbv2.document.RangeKeyCondition;
 import com.google.common.collect.Iterables;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTime;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;

--- a/src/main/java/org/sagebionetworks/bridge/exporter/request/BridgeExporterRequest.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/request/BridgeExporterRequest.java
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTime;
 
 import org.sagebionetworks.bridge.json.DateTimeDeserializer;

--- a/src/main/java/org/sagebionetworks/bridge/exporter/synapse/SynapseTableIterator.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/synapse/SynapseTableIterator.java
@@ -5,7 +5,7 @@ import java.util.NoSuchElementException;
 import java.util.concurrent.TimeUnit;
 
 import com.jcabi.aspects.RetryOnFailure;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.sagebionetworks.client.SynapseClient;
 import org.sagebionetworks.client.exceptions.SynapseClientException;
 import org.sagebionetworks.client.exceptions.SynapseException;

--- a/src/main/java/org/sagebionetworks/bridge/exporter/worker/ExportWorkerManager.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/worker/ExportWorkerManager.java
@@ -25,11 +25,11 @@ import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.ImmutableSet;
 import com.google.gson.JsonParseException;
 import com.google.gson.stream.MalformedJsonException;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.sagebionetworks.client.exceptions.SynapseException;
-import org.sagebionetworks.client.exceptions.SynapseServerException;
+import org.sagebionetworks.client.exceptions.SynapseServiceUnavailable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -708,7 +708,7 @@ public class ExportWorkerManager {
     //
     // Package-scoped for unit tests.
     static boolean isSynapseDown(Throwable t) {
-        return (t instanceof SynapseServerException && ((SynapseServerException)t).getStatusCode() == 503);
+        return t instanceof SynapseServiceUnavailable;
     }
 
     // For redrives, we need to know whether an exception is retryable or not. If it is, we can redrive it. If not, we

--- a/src/test/java/org/sagebionetworks/bridge/exporter/worker/ExportWorkerManagerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/worker/ExportWorkerManagerTest.java
@@ -24,8 +24,10 @@ import com.google.common.collect.ImmutableMap;
 import com.google.gson.JsonParseException;
 import com.google.gson.stream.MalformedJsonException;
 import org.mockito.ArgumentCaptor;
+import org.sagebionetworks.client.exceptions.SynapseBadRequestException;
 import org.sagebionetworks.client.exceptions.SynapseClientException;
-import org.sagebionetworks.client.exceptions.SynapseServerException;
+import org.sagebionetworks.client.exceptions.SynapseServiceUnavailable;
+import org.sagebionetworks.client.exceptions.UnknownSynapseServerException;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -426,9 +428,9 @@ public class ExportWorkerManagerTest {
                 { new IllegalArgumentException(), false },
                 { new BridgeExporterException(), false },
                 { new SynapseClientException(), false },
-                { new SynapseServerException(404), false },
-                { new SynapseServerException(500), false },
-                { new SynapseServerException(503), true },
+                { new SynapseBadRequestException(), false },
+                { new UnknownSynapseServerException(500), false },
+                { new SynapseServiceUnavailable("Service Unavailable"), true },
 
                 // branch coverage
                 { null, false },


### PR DESCRIPTION
We were asked to update the SynapseJavaClient so that the Synapse team could deprecate some stuff. There were some breaking changes and some dependency conflicts we had to resolve, but there should be no functional changes.