### PR TITLE
downgrade truncation error to warning

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/exporter/util/BridgeExporterUtil.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/util/BridgeExporterUtil.java
@@ -171,7 +171,7 @@ public class BridgeExporterUtil {
 
         // Check against max length, truncating and warning as necessary.
         if (maxLength != null && in.length() > maxLength) {
-            LOG.error("Truncating string for field " + fieldName + " in record " + recordId + " in study " + studyId +
+            LOG.warn("Truncating string for field " + fieldName + " in record " + recordId + " in study " + studyId +
                     ", original length " + in.length() + " to max length " + maxLength);
             in = in.substring(0, maxLength);
         }


### PR DESCRIPTION
These errors aren't really actionable. Usually it means someone is sending overly long strings to us and it's getting truncated in Synapse. We don't want to be in the business of chasing down someone else's data issues (not when everything is available in rawData, anyway), so we're downgrading this error to a warning.