### PR TITLE
downgrade truncation warning to info

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/exporter/util/BridgeExporterUtil.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/util/BridgeExporterUtil.java
@@ -171,7 +171,7 @@ public class BridgeExporterUtil {
 
         // Check against max length, truncating and warning as necessary.
         if (maxLength != null && in.length() > maxLength) {
-            LOG.warn("Truncating string for field " + fieldName + " in record " + recordId + " in study " + studyId +
+            LOG.info("Truncating string for field " + fieldName + " in record " + recordId + " in study " + studyId +
                     ", original length " + in.length() + " to max length " + maxLength);
             in = in.substring(0, maxLength);
         }


### PR DESCRIPTION
We had previously downgraded this error to a warning in https://github.com/Sage-Bionetworks/Bridge-Exporter/pull/92 However, this is still happening hundreds of times per day and is still not actionable.

Downgrading from warning to info.