### PR TITLE
log temp dir location

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/exporter/record/BridgeExporterRecordProcessor.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/record/BridgeExporterRecordProcessor.java
@@ -153,6 +153,7 @@ public class BridgeExporterRecordProcessor {
         // make task
         Metrics metrics = new Metrics();
         File tmpDir = fileHelper.createTempDir();
+        LOG.info("Created temp dir " + tmpDir.getAbsolutePath());
         ExportTask task = new ExportTask.Builder().withExporterDate(LocalDate.now(timeZone)).withMetrics(metrics)
                 .withRequest(request).withTmpDir(tmpDir).build();
 


### PR DESCRIPTION
Sometimes, we need to track down a file on disk to do diagnostics. Unfortunately, we don't know where that file is. This logs the temp dir location so we can find the file later.