### PR TITLE
Minimal changes needed to relax ObjectMapper config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>org.sagebionetworks</groupId>
             <artifactId>bridge-base</artifactId>
-            <version>2.7.24</version>
+            <version>2.7.26</version>
         </dependency>
         <dependency>
             <groupId>org.sagebionetworks.bridge</groupId>

--- a/src/main/java/org/sagebionetworks/bridge/exporter/handler/AppVersionExportHandler.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/handler/AppVersionExportHandler.java
@@ -88,7 +88,7 @@ public class AppVersionExportHandler extends SynapseExportHandler {
         String originalTable;
         if (schemaKey == null) {
             originalTable = BridgeExporterUtil.DEFAULT_TABLE_NAME;
-        } else if (getManager().isStudyIdExcludedInExportForStudy(schemaKey.getStudyId())) {
+        } else if (getManager().isStudyIdExcludedInExportForStudy(schemaKey.getAppId())) {
             originalTable = schemaKey.getSchemaId() + "-v" + schemaKey.getRevision();
         } else {
             originalTable = schemaKey.toString();

--- a/src/main/java/org/sagebionetworks/bridge/exporter/handler/IosSurveyExportHandler.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/handler/IosSurveyExportHandler.java
@@ -67,7 +67,7 @@ public class IosSurveyExportHandler extends ExportHandler {
         @SuppressWarnings("UnnecessaryLocalVariable")
         String schemaId = item;
         int schemaRev = 1;
-        UploadSchemaKey surveySchemaKey = new UploadSchemaKey.Builder().withStudyId(studyId)
+        UploadSchemaKey surveySchemaKey = new UploadSchemaKey.Builder().withAppId(studyId)
                 .withSchemaId(schemaId).withRevision(schemaRev).build();
 
         // get schema and field type map, so we can process attachments

--- a/src/main/java/org/sagebionetworks/bridge/exporter/helper/BridgeHelper.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/helper/BridgeHelper.java
@@ -112,7 +112,7 @@ public class BridgeHelper {
     @Cacheable(lifetime = 5, unit = TimeUnit.MINUTES)
     private UploadSchema getSchemaCached(UploadSchemaKey schemaKey) {
         try {
-            return bridgeClientManager.getClient(ForWorkersApi.class).getSchemaRevisionInStudy(schemaKey.getStudyId(),
+            return bridgeClientManager.getClient(ForWorkersApi.class).getSchemaRevisionInStudy(schemaKey.getAppId(),
                     schemaKey.getSchemaId(), (long) schemaKey.getRevision()).execute().body();
         } catch (IOException ex) {
             throw new BridgeSDKException("Error getting schema from Bridge: " + ex.getMessage(), ex);

--- a/src/main/java/org/sagebionetworks/bridge/exporter/request/BridgeExporterRequest.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/request/BridgeExporterRequest.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -274,11 +275,12 @@ public class BridgeExporterRequest {
         }
 
         /** @see BridgeExporterRequest#getStudyWhitelist */
+        @JsonAlias("appWhitelist")
         public Builder withStudyWhitelist(Set<String> studyWhitelist) {
             this.studyWhitelist = studyWhitelist;
             return this;
         }
-
+        
         /** @see BridgeExporterRequest#getSynapseProjectOverrideMap */
         public Builder withSynapseProjectOverrideMap(Map<String, String> synapseProjectOverrideMap) {
             this.synapseProjectOverrideMap = synapseProjectOverrideMap;

--- a/src/main/java/org/sagebionetworks/bridge/exporter/util/BridgeExporterUtil.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/util/BridgeExporterUtil.java
@@ -70,7 +70,7 @@ public class BridgeExporterUtil {
         String studyId = record.getString("studyId");
         String schemaId = record.getString("schemaId");
         int schemaRev = record.getInt("schemaRevision");
-        return new UploadSchemaKey.Builder().withStudyId(studyId).withSchemaId(schemaId).withRevision(schemaRev)
+        return new UploadSchemaKey.Builder().withAppId(studyId).withSchemaId(schemaId).withRevision(schemaRev)
                 .build();
     }
 
@@ -88,7 +88,7 @@ public class BridgeExporterUtil {
         if (schema.getRevision() == null) {
             throw new IllegalArgumentException("revision can't be null");
         }
-        return new UploadSchemaKey.Builder().withStudyId(schema.getStudyId()).withSchemaId(schema.getSchemaId())
+        return new UploadSchemaKey.Builder().withAppId(schema.getStudyId()).withSchemaId(schema.getSchemaId())
                 .withRevision(schema.getRevision().intValue()).build();
     }
 

--- a/src/main/java/org/sagebionetworks/bridge/exporter/worker/ExportWorkerManager.java
+++ b/src/main/java/org/sagebionetworks/bridge/exporter/worker/ExportWorkerManager.java
@@ -484,7 +484,7 @@ public class ExportWorkerManager {
         SchemaBasedExportHandler handler = new SchemaBasedExportHandler();
         handler.setManager(this);
         handler.setSchemaKey(schemaKey);
-        handler.setStudyId(schemaKey.getStudyId());
+        handler.setStudyId(schemaKey.getAppId());
         return handler;
     }
 
@@ -621,7 +621,7 @@ public class ExportWorkerManager {
                             originalEx.getMessage(), originalEx);
                     if (isRetryable(originalEx)) {
                         // Similarly, track which tables (schemas) to redrive.
-                        String studyId = schemaKey.getStudyId();
+                        String studyId = schemaKey.getAppId();
                         Set<UploadSchemaKey> redriveTableSet = redriveTablesByStudy.get(studyId);
                         if (redriveTableSet == null) {
                             redriveTableSet = new HashSet<>();

--- a/src/test/java/org/sagebionetworks/bridge/exporter/handler/HealthDataExportHandlerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/handler/HealthDataExportHandlerTest.java
@@ -6,7 +6,6 @@ import static org.mockito.Matchers.notNull;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;

--- a/src/test/java/org/sagebionetworks/bridge/exporter/handler/IosSurveyExportHandlerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/handler/IosSurveyExportHandlerTest.java
@@ -49,9 +49,9 @@ public class IosSurveyExportHandlerTest {
             .withEndDateTime(DUMMY_REQUEST_DATE_TIME).withUseLastExportTime(true).build();
     private static final String TEST_STUDY_ID = "testStudy";
     private static final UploadSchemaKey SCHEMA_KEY_PLACEHOLDER = new UploadSchemaKey.Builder()
-            .withStudyId(TEST_STUDY_ID).withSchemaId("ios-survey").withRevision(1).build();
+            .withAppId(TEST_STUDY_ID).withSchemaId("ios-survey").withRevision(1).build();
     private static final UploadSchemaKey SCHEMA_KEY_REAL = new UploadSchemaKey.Builder()
-            .withStudyId(TEST_STUDY_ID).withSchemaId("Daily-Quiz").withRevision(1).build();
+            .withAppId(TEST_STUDY_ID).withSchemaId("Daily-Quiz").withRevision(1).build();
 
     ExportSubtask.Builder subtaskBuilder;
     IosSurveyExportHandler handler;

--- a/src/test/java/org/sagebionetworks/bridge/exporter/handler/SynapseExportHandlerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/handler/SynapseExportHandlerTest.java
@@ -98,7 +98,7 @@ public class SynapseExportHandlerTest {
     public static final String TEST_STUDY_ID = "my-study";
     public static final String TEST_SCHEMA_ID = "my-schema";
     public static final int TEST_SCHEMA_REV = 1;
-    public static final UploadSchemaKey DUMMY_SCHEMA_KEY = new UploadSchemaKey.Builder().withStudyId(TEST_STUDY_ID)
+    public static final UploadSchemaKey DUMMY_SCHEMA_KEY = new UploadSchemaKey.Builder().withAppId(TEST_STUDY_ID)
             .withSchemaId(TEST_SCHEMA_ID).withRevision(TEST_SCHEMA_REV).build();
 
     // Misc test constants. Some are shared with other tests.

--- a/src/test/java/org/sagebionetworks/bridge/exporter/helper/BridgeHelperTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/helper/BridgeHelperTest.java
@@ -59,7 +59,7 @@ public class BridgeHelperTest {
 
     public static final UploadSchema TEST_SCHEMA = simpleSchemaBuilder().fieldDefinitions(ImmutableList.of(
             TEST_FIELD_DEF));
-    public static final UploadSchemaKey TEST_SCHEMA_KEY = new UploadSchemaKey.Builder().withStudyId(TEST_STUDY_ID)
+    public static final UploadSchemaKey TEST_SCHEMA_KEY = new UploadSchemaKey.Builder().withAppId(TEST_STUDY_ID)
             .withSchemaId(TEST_SCHEMA_ID).withRevision(TEST_SCHEMA_REV).build();
 
     public BridgeHelper bridgeHelper;

--- a/src/test/java/org/sagebionetworks/bridge/exporter/record/RecordFilterHelperTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/record/RecordFilterHelperTest.java
@@ -202,7 +202,7 @@ public class RecordFilterHelperTest {
     public void tableFilterAccepts() {
         // set up inputs
         Metrics metrics = new Metrics();
-        UploadSchemaKey acceptedSchemaKey = new UploadSchemaKey.Builder().withStudyId(TEST_STUDY)
+        UploadSchemaKey acceptedSchemaKey = new UploadSchemaKey.Builder().withAppId(TEST_STUDY)
                 .withSchemaId("test-schema").withRevision(3).build();
         BridgeExporterRequest request = makeRequestBuilder().withTableWhitelist(ImmutableSet.of(acceptedSchemaKey))
                 .build();
@@ -222,7 +222,7 @@ public class RecordFilterHelperTest {
     public void tableFilterExcludes() {
         // set up inputs
         Metrics metrics = new Metrics();
-        UploadSchemaKey acceptedSchemaKey = new UploadSchemaKey.Builder().withStudyId(TEST_STUDY)
+        UploadSchemaKey acceptedSchemaKey = new UploadSchemaKey.Builder().withAppId(TEST_STUDY)
                 .withSchemaId("test-schema").withRevision(3).build();
         BridgeExporterRequest request = makeRequestBuilder().withTableWhitelist(ImmutableSet.of(acceptedSchemaKey))
                 .build();
@@ -244,7 +244,7 @@ public class RecordFilterHelperTest {
     public void tableFilterExcludesSchemaless() {
         // Set up inputs.
         Metrics metrics = new Metrics();
-        UploadSchemaKey acceptedSchemaKey = new UploadSchemaKey.Builder().withStudyId(TEST_STUDY)
+        UploadSchemaKey acceptedSchemaKey = new UploadSchemaKey.Builder().withAppId(TEST_STUDY)
                 .withSchemaId("test-schema").withRevision(3).build();
         BridgeExporterRequest request = makeRequestBuilder().withTableWhitelist(ImmutableSet.of(acceptedSchemaKey))
                 .build();

--- a/src/test/java/org/sagebionetworks/bridge/exporter/request/BridgeExporterRequestTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/request/BridgeExporterRequestTest.java
@@ -31,7 +31,7 @@ public class BridgeExporterRequestTest {
     private static final Map<String, String> TEST_PROJECT_OVERRIDE_MAP = ImmutableMap.of("test-study",
             "test-project-id");
     private static final String TEST_RECORD_OVERRIDE = "test-record-override";
-    private static final UploadSchemaKey TEST_SCHEMA_KEY = new UploadSchemaKey.Builder().withStudyId("test-study")
+    private static final UploadSchemaKey TEST_SCHEMA_KEY = new UploadSchemaKey.Builder().withAppId("test-study")
             .withSchemaId("test-schema").withRevision(13).build();
     private static final String TEST_TAG = "test-tag";
 
@@ -100,9 +100,9 @@ public class BridgeExporterRequestTest {
         originalProjectOverrideMap.put("foo-study", "foo-project-id");
         originalProjectOverrideMap.put("bar-study", "bar-project-id");
 
-        UploadSchemaKey fooSchemaKey = new UploadSchemaKey.Builder().withStudyId("foo-study")
+        UploadSchemaKey fooSchemaKey = new UploadSchemaKey.Builder().withAppId("foo-study")
                 .withSchemaId("foo-schema").withRevision(3).build();
-        UploadSchemaKey barSchemaKey = new UploadSchemaKey.Builder().withStudyId("bar-study")
+        UploadSchemaKey barSchemaKey = new UploadSchemaKey.Builder().withAppId("bar-study")
                 .withSchemaId("bar-schema").withRevision(7).build();
         Set<UploadSchemaKey> originalTableWhitelist = Sets.newHashSet(fooSchemaKey, barSchemaKey);
 
@@ -395,11 +395,26 @@ public class BridgeExporterRequestTest {
         assertEquals(tableWhitelistNode.size(), 1);
         assertTrue(tableWhitelistNode.get(0).isObject());
         assertEquals(tableWhitelistNode.get(0).size(), 3);
-        assertEquals(tableWhitelistNode.get(0).get("studyId").textValue(), "test-study");
+        assertEquals(tableWhitelistNode.get(0).get("appId").textValue(), "test-study");
         assertEquals(tableWhitelistNode.get(0).get("schemaId").textValue(), "test-schema");
         assertEquals(tableWhitelistNode.get(0).get("revision").intValue(), 13);
     }
 
+    public void jsonSerializationWithAppWhitelist() throws Exception {
+        // start with JSON
+        String jsonText = "{\n" +
+                "   \"exporterDdbPrefixOverride\":\"" + TEST_DDB_PREFIX_OVERRIDE + "\",\n" +
+                "   \"recordIdS3Override\":\"" + TEST_RECORD_OVERRIDE + "\",\n" +
+                "   \"redriveCount\":2,\n" +
+                "   \"sharingMode\":\"PUBLIC_ONLY\",\n" +
+                "   \"appWhitelist\":[\"test-study\"]\n" +
+                "}";
+
+        // convert to POJO
+        BridgeExporterRequest request = DefaultObjectMapper.INSTANCE.readValue(jsonText, BridgeExporterRequest.class);
+        assertEquals(request.getStudyWhitelist(), ImmutableSet.of("test-study"));
+    }
+    
     @Test
     public void equalsVerifier() {
         EqualsVerifier.forClass(BridgeExporterRequest.class).allFieldsShouldBeUsed().verify();

--- a/src/test/java/org/sagebionetworks/bridge/exporter/util/BridgeExporterUtilTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/util/BridgeExporterUtilTest.java
@@ -82,7 +82,7 @@ public class BridgeExporterUtilTest {
 
         // execute and validate
         UploadSchemaKey schemaKey = BridgeExporterUtil.getSchemaKeyFromSchema(schema);
-        assertEquals(schemaKey.getStudyId(), "test-study");
+        assertEquals(schemaKey.getAppId(), "test-study");
         assertEquals(schemaKey.getSchemaId(), "test-schema");
         assertEquals(schemaKey.getRevision(), 3);
     }

--- a/src/test/java/org/sagebionetworks/bridge/exporter/worker/ExportSubtaskTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/worker/ExportSubtaskTest.java
@@ -27,7 +27,7 @@ public class ExportSubtaskTest {
             .withTmpDir(mock(File.class)).build();
 
     private static final JsonNode DUMMY_RECORD_DATA = DefaultObjectMapper.INSTANCE.createObjectNode();
-    private static final UploadSchemaKey DUMMY_SCHEMA_KEY = new UploadSchemaKey.Builder().withStudyId("test-study")
+    private static final UploadSchemaKey DUMMY_SCHEMA_KEY = new UploadSchemaKey.Builder().withAppId("test-study")
             .withSchemaId("test-schema").withRevision(17).build();
     private static final String STUDY_ID = "my-study";
 

--- a/src/test/java/org/sagebionetworks/bridge/exporter/worker/ExportTaskTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/worker/ExportTaskTest.java
@@ -99,12 +99,12 @@ public class ExportTaskTest {
         ExportTask task = createTask();
 
         // set values
-        UploadSchemaKey fooSchemaKey = new UploadSchemaKey.Builder().withStudyId("test-study")
+        UploadSchemaKey fooSchemaKey = new UploadSchemaKey.Builder().withAppId("test-study")
                 .withSchemaId("foo-schema").withRevision(3).build();
         TsvInfo fooTsvInfo = createTsvInfo();
         task.setHealthDataTsvInfoForSchema(fooSchemaKey, fooTsvInfo);
 
-        UploadSchemaKey barSchemaKey = new UploadSchemaKey.Builder().withStudyId("test-study")
+        UploadSchemaKey barSchemaKey = new UploadSchemaKey.Builder().withAppId("test-study")
                 .withSchemaId("bar-schema").withRevision(7).build();
         TsvInfo barTsvInfo = createTsvInfo();
         task.setHealthDataTsvInfoForSchema(barSchemaKey, barTsvInfo);

--- a/src/test/java/org/sagebionetworks/bridge/exporter/worker/ExportWorkerManagerEndOfStreamTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/worker/ExportWorkerManagerEndOfStreamTest.java
@@ -314,19 +314,19 @@ public class ExportWorkerManagerEndOfStreamTest {
         assertEquals(redriveTableARequest.getStartDateTime(), startDateTimeByStudy.get("study-A"));
         assertEquals(redriveTableARequest.getStudyWhitelist(), ImmutableSet.of("study-A"));
         assertEquals(redriveTableARequest.getTableWhitelist(), ImmutableSet.of(new UploadSchemaKey.Builder()
-                .withStudyId("study-A").withSchemaId("schema-A").withRevision(1).build()));
+                .withAppId("study-A").withSchemaId("schema-A").withRevision(1).build()));
 
         BridgeExporterRequest redriveTableCRequest = redriveRequestList.get(2);
         assertEquals(redriveTableCRequest.getStartDateTime(), startDateTimeByStudy.get("study-C"));
         assertEquals(redriveTableCRequest.getStudyWhitelist(), ImmutableSet.of("study-C"));
         assertEquals(redriveTableCRequest.getTableWhitelist(), ImmutableSet.of(new UploadSchemaKey.Builder()
-                .withStudyId("study-C").withSchemaId("schema-C").withRevision(1).build()));
+                .withAppId("study-C").withSchemaId("schema-C").withRevision(1).build()));
 
         BridgeExporterRequest redriveTableERequest = redriveRequestList.get(3);
         assertEquals(redriveTableERequest.getStartDateTime(), startDateTimeByStudy.get("study-E"));
         assertEquals(redriveTableERequest.getStudyWhitelist(), ImmutableSet.of("study-E"));
         assertEquals(redriveTableERequest.getTableWhitelist(), ImmutableSet.of(new UploadSchemaKey.Builder()
-                .withStudyId("study-E").withSchemaId("schema-E").withRevision(1).build()));
+                .withAppId("study-E").withSchemaId("schema-E").withRevision(1).build()));
     }
 
     @Test
@@ -417,9 +417,9 @@ public class ExportWorkerManagerEndOfStreamTest {
         assertEquals(redriveTableRequest.getSharingMode(), request.getSharingMode());
         assertEquals(redriveTableRequest.getStudyWhitelist(), ImmutableSet.of(TEST_STUDY));
         assertEquals(redriveTableRequest.getTableWhitelist(), ImmutableSet.of(
-                new UploadSchemaKey.Builder().withStudyId(TEST_STUDY).withSchemaId("schema-A").withRevision(1)
+                new UploadSchemaKey.Builder().withAppId(TEST_STUDY).withSchemaId("schema-A").withRevision(1)
                         .build(),
-                new UploadSchemaKey.Builder().withStudyId(TEST_STUDY).withSchemaId("schema-B").withRevision(1)
+                new UploadSchemaKey.Builder().withAppId(TEST_STUDY).withSchemaId("schema-B").withRevision(1)
                         .build()));
         assertEquals(redriveTableRequest.getTag(), ExportWorkerManager.REDRIVE_TAG_PREFIX + request.getTag());
         assertFalse(redriveTableRequest.getUseLastExportTime());
@@ -472,9 +472,9 @@ public class ExportWorkerManagerEndOfStreamTest {
         assertEquals(redriveTableRequest.getSharingMode(), request.getSharingMode());
         assertEquals(redriveTableRequest.getStudyWhitelist(), ImmutableSet.of(TEST_STUDY));
         assertEquals(redriveTableRequest.getTableWhitelist(), ImmutableSet.of(
-                new UploadSchemaKey.Builder().withStudyId(TEST_STUDY).withSchemaId("schema-A").withRevision(1)
+                new UploadSchemaKey.Builder().withAppId(TEST_STUDY).withSchemaId("schema-A").withRevision(1)
                         .build(),
-                new UploadSchemaKey.Builder().withStudyId(TEST_STUDY).withSchemaId("schema-B").withRevision(1)
+                new UploadSchemaKey.Builder().withAppId(TEST_STUDY).withSchemaId("schema-B").withRevision(1)
                         .build()));
         assertEquals(redriveTableRequest.getTag(), ExportWorkerManager.REDRIVE_TAG_PREFIX + request.getTag());
         assertFalse(redriveTableRequest.getUseLastExportTime());
@@ -536,7 +536,7 @@ public class ExportWorkerManagerEndOfStreamTest {
 
         Set<UploadSchemaKey> redriveTableWhitelist = redriveTableRequest.getTableWhitelist();
         assertEquals(redriveTableWhitelist.size(), 1);
-        assertTrue(redriveTableWhitelist.contains(new UploadSchemaKey.Builder().withStudyId(TEST_STUDY)
+        assertTrue(redriveTableWhitelist.contains(new UploadSchemaKey.Builder().withAppId(TEST_STUDY)
                 .withSchemaId("test-schema").withRevision(1).build()));
     }
 

--- a/src/test/java/org/sagebionetworks/bridge/exporter/worker/ExportWorkerManagerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/worker/ExportWorkerManagerTest.java
@@ -299,7 +299,7 @@ public class ExportWorkerManagerTest {
         when(mockTask.getMetrics()).thenReturn(new Metrics());
 
         // mock DynamoHelper to get schema
-        UploadSchemaKey testSchemaKey = new UploadSchemaKey.Builder().withStudyId(TEST_STUDY_ID)
+        UploadSchemaKey testSchemaKey = new UploadSchemaKey.Builder().withAppId(TEST_STUDY_ID)
                 .withSchemaId(TEST_SCHEMA_ID).withRevision(TEST_SCHEMA_REV).build();
         BridgeHelper mockBridgeHelper = mock(BridgeHelper.class);
         when(mockBridgeHelper.getSchema(notNull(Metrics.class), eq(testSchemaKey))).thenReturn(


### PR DESCRIPTION
The exporter receives requests to "export immediately" through JSON and a queue, and again the ObjectMapper needs to be configured to allow appId alongside the existing properties.