### PR TITLE
Updates for migration to Amazon Linux 2023

### DIFF
--- a/ebextensions/newrelic.config
+++ b/ebextensions/newrelic.config
@@ -17,7 +17,7 @@ container_commands:
     command: "echo -e \"\ndisplay_name: $NEW_RELIC_APP_NAME\" >> /etc/newrelic-infra.yml"
 # Install NR infrastructure agent
   "13SetupInfraAgentRepo":
-    command: sudo curl -o /etc/yum.repos.d/newrelic-infra.repo https://download.newrelic.com/infrastructure_agent/linux/yum/el/6/x86_64/newrelic-infra.repo
+    command: sudo curl -o /etc/yum.repos.d/newrelic-infra.repo https://download.newrelic.com/infrastructure_agent/linux/yum/amazonlinux/2023/x86_64/newrelic-infra.repo
   "14UpdateInfraAgentYumCache":
     command: sudo yum -q makecache -y --disablerepo='*' --enablerepo='newrelic-infra'
   "20InstallInfraAgent":

--- a/ebextensions/tomcatlogs.config
+++ b/ebextensions/tomcatlogs.config
@@ -1,33 +1,37 @@
 ###################################################################################################
-#### The configuration below sets the logs to be pushed, the Log Group name to push the logs to and
-#### the Log Stream name as the instance id. The following files are examples of logs that will be
-#### streamed to CloudWatch Logs in near real time:
-#### 
-#### /var/log/tomcat/catalina.out
-#### 
-#### You can then access the CloudWatch Logs by accessing the AWS CloudWatch Console and clicking
-#### the "Logs" link on the left. The Log Group name will follow this format:
+#### Streams Tomcat's catalina.out to CloudWatch Logs.
 ####
-#### /aws/elasticbeanstalk/<environment name>/<full log name path>
+#### On AL2023 the legacy `awslogs`/`awslogsd` agent is no longer available, so this uses the
+#### unified CloudWatch agent (`amazon-cloudwatch-agent`), which is preinstalled on the platform.
+#### Config is dropped into the agent's etc/ dir and merged in with `append-config` so we don't
+#### clobber the platform-provided agent config. Log group names follow EB's convention:
 ####
-#### Please note this configuration can be used additionally to the "Log Streaming" feature:
-#### http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/AWSHowTo.cloudwatchlogs.html
+####     /aws/elasticbeanstalk/<environment name>/<full on-instance log path>
+####
+#### Retention is managed at the CloudWatch Logs group level, so it is intentionally not set here.
 ###################################################################################################
 
-packages:
-  yum:
-    awslogs: []
-
 files:
-  "/etc/awslogs/config/tomcatlogs.conf" :
+  "/opt/aws/amazon-cloudwatch-agent/etc/tomcat-logs.json":
     mode: "000644"
     owner: root
     group: root
     content: |
-      [/var/log/tomcat/catalina.out]
-      log_group_name=`{"Fn::Join":["/", ["/aws/elasticbeanstalk", { "Ref":"AWSEBEnvironmentName" }, "var/log/tomcat/catalina.out"]]}`
-      log_stream_name={instance_id}
-      file=/var/log/tomcat/catalina.out*
+      {
+        "logs": {
+          "logs_collected": {
+            "files": {
+              "collect_list": [
+                {
+                  "file_path": "/var/log/tomcat/catalina.out",
+                  "log_group_name": "`{"Fn::Join":["/", ["/aws/elasticbeanstalk", { "Ref":"AWSEBEnvironmentName" }, "var/log/tomcat/catalina.out"]]}`",
+                  "log_stream_name": "{instance_id}"
+                }
+              ]
+            }
+          }
+        }
+      }
 
   "/etc/rsyslog.d/catalina.conf":
     mode: "0644"
@@ -42,17 +46,11 @@ files:
         *.=info;*.=notice /var/log/tomcat/catalina.out;catalinalog
        }
 
-commands:
-  "02a_systemctl_start_awslogsd":
-    command: systemctl start awslogsd
+container_commands:
+  "01_append_cloudwatch_agent_config":
+    command: "/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a append-config -s -c file:/opt/aws/amazon-cloudwatch-agent/etc/tomcat-logs.json"
+  "02_remove_backup_file":
+    command: "rm -f /opt/aws/amazon-cloudwatch-agent/etc/tomcat-logs.json.bak"
     ignoreErrors: true
-
-  "02b_systemctl_enable_awslogsd_service":
-    command: systemctl enable awslogsd.service
-    ignoreErrors: true
-
-  "02c_restart_awslogs":
-    command: service awslogsd restart
-
   "03_restart_rsyslog":
-    command: systemctl restart rsyslog
+    command: "systemctl restart rsyslog"


### PR DESCRIPTION
The infra-agent yum repo URL still referenced the el/6 (RHEL 6) path,
which is not valid on AL2023. Use the amazonlinux/2023 repo so the
agent installs on the AL2023 platform.

The awslogs/awslogsd agent is removed on AL2023, so installing the
awslogs package and starting awslogsd fails the deploy. Replace it with
the preinstalled unified CloudWatch agent (amazon-cloudwatch-agent):

- Write a CloudWatch agent JSON config and merge it with append-config
  so the platform-provided agent config is preserved.
- Keep the EB log-group naming and the rsyslog redirect that populates
  catalina.out.
- Omit retention_in_days; retention is managed at the log-group level.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>